### PR TITLE
Allow custom annotations

### DIFF
--- a/helm-chart/eoapi/templates/services/ingress-nginx.yaml
+++ b/helm-chart/eoapi/templates/services/ingress-nginx.yaml
@@ -18,6 +18,9 @@ metadata:
     {{- if (and (.Values.ingress.tls.enabled) (.Values.ingress.tls.certManager)) }}
     cert-manager.io/issuer: {{ .Values.ingress.tls.certManagerIssuer }}
     {{- end }}
+{{- if (.Values.ingress.annotations) }}
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- end }}
 spec:
   {{- if (and (.Values.ingress.className) (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion)) }}
   ingressClassName: {{ .Values.ingress.className }}


### PR DESCRIPTION
Allow custom annotations to be added via `values.yaml`. For [example](https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/#key-detail), when using `oauth2-proxy` to hide API behind auth.

```
ingress:
  annotations:
    nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
    nginx.ingress.kubernetes.io/enable-cors: "true"
```