### PR TITLE
fix: remove VSIL allowed extensions list

### DIFF
--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -214,7 +214,6 @@ raster:
       ##############
       # titiler
       ##############
-      CPL_VSIL_CURL_ALLOWED_EXTENSIONS: ".tif,.TIF,.tiff"
       GDAL_CACHEMAX: "200"  # 200 mb
       GDAL_DISABLE_READDIR_ON_OPEN: "EMPTY_DIR"
       GDAL_INGESTED_BYTES_AT_OPEN: "32768"


### PR DESCRIPTION
# What this PR is 

Removes unnecessary restrictive list of allowed file extensions when using VSI curl - This can instead be set by the user of the chart
