### PR TITLE
feat: bump eoapi chart and app versions

### DIFF
--- a/helm-chart/eoapi/Chart.yaml
+++ b/helm-chart/eoapi/Chart.yaml
@@ -15,13 +15,13 @@ kubeVersion: ">=1.23.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.4.17"
+version: "0.5.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.21"
+appVersion: "0.4.0"
 
 dependencies:
   - name: postgrescluster


### PR DESCRIPTION
Incremented the version and tagged this commit as `eoapi-0.5.0`

## What's Changed

- feat: upgrade TiTiler-PgSTAC to v1.4.0 (see [changelog](https://github.com/stac-utils/titiler-pgstac/blob/main/CHANGES.md#140-2024-09-06)) in #157
- feat: bump chart and app versions in #158

## New Contributors

- @j08lue made their first contribution in #158