### PR TITLE
Nest raster, vector and stac services into apiServices.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ ingest:
 	@command -v bash >/dev/null 2>&1 || { echo "bash is required but not installed"; exit 1; }
 	@./ingest.sh || { echo "Ingestion failed."; exit 1; }
 
+tests:
+	@echo "Running tests."
+	@command -v helm >/dev/null 2>&1 || { echo "helm is required but not installed"; exit 1; }
+	@helm unittest helm-chart/eoapi -f 'tests/*.yaml' -v helm-chart/eoapi/test-helm-values.yaml
+
 help:
 	@echo "Makefile commands:"
 	@echo "  make deploy         -  Install eoAPI on a cluster kubectl is connected to."

--- a/helm-chart/eoapi/Chart.yaml
+++ b/helm-chart/eoapi/Chart.yaml
@@ -15,7 +15,7 @@ kubeVersion: ">=1.23.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.5.2"
+version: "0.5.3"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-chart/eoapi/templates/_helpers.tpl
+++ b/helm-chart/eoapi/templates/_helpers.tpl
@@ -159,11 +159,23 @@ so we use this helper function to check autoscaling rules
 {{- define "eoapi.validateAutoscaleRules" -}}
 {{- if and .Values.ingress.enabled (ne .Values.ingress.className "nginx") }}
 {{/* "requestRate" cannot be enabled for any service if not "nginx" so give feedback and fail */}}
-{{- if (or (and .Values.raster.autoscaling.enabled (eq .Values.raster.autoscaling.type "requestRate")) (and .Values.stac.autoscaling.enabled (eq .Values.stac.autoscaling.type "requestRate")) (and .Values.vector.autoscaling.enabled (eq .Values.vector.autoscaling.type "requestRate")) ) }}
+{{- $hasRequestRate := false }}
+{{- range $serviceName, $service := .Values.externalServices }}
+  {{- if and $service.autoscaling.enabled (eq $service.autoscaling.type "requestRate") }}
+    {{- $hasRequestRate = true }}
+  {{- end }}
+{{- end }}
+{{- if $hasRequestRate }}
 {{- fail "When using an 'ingress.className' other than 'nginx' you cannot enable autoscaling by 'requestRate' at this time b/c it's solely an nginx metric" }}
 {{- end }}
 {{/* "both" cannot be enabled for any service if not "nginx" so give feedback and fail */}}
-{{- if (or (and .Values.raster.autoscaling.enabled (eq .Values.raster.autoscaling.type "both")) (and .Values.stac.autoscaling.enabled (eq .Values.stac.autoscaling.type "both")) (and .Values.vector.autoscaling.enabled (eq .Values.vector.autoscaling.type "both")) ) }}
+{{- $hasBoth := false }}
+{{- range $serviceName, $service := .Values.externalServices }}
+  {{- if and $service.autoscaling.enabled (eq $service.autoscaling.type "both") }}
+    {{- $hasBoth = true }}
+  {{- end }}
+{{- end }}
+{{- if $hasBoth }}
 {{- fail "When using an 'ingress.className' other than 'nginx' you cannot enable autoscaling by 'both' at this time b/c 'requestRate' is solely an nginx metric" }}
 {{- end }}
 {{- end }}

--- a/helm-chart/eoapi/templates/_helpers.tpl
+++ b/helm-chart/eoapi/templates/_helpers.tpl
@@ -160,7 +160,7 @@ so we use this helper function to check autoscaling rules
 {{- if and .Values.ingress.enabled (ne .Values.ingress.className "nginx") }}
 {{/* "requestRate" cannot be enabled for any service if not "nginx" so give feedback and fail */}}
 {{- $hasRequestRate := false }}
-{{- range $serviceName, $service := .Values.externalServices }}
+{{- range $serviceName, $service := .Values.apiServices }}
   {{- if and $service.autoscaling.enabled (eq $service.autoscaling.type "requestRate") }}
     {{- $hasRequestRate = true }}
   {{- end }}
@@ -170,7 +170,7 @@ so we use this helper function to check autoscaling rules
 {{- end }}
 {{/* "both" cannot be enabled for any service if not "nginx" so give feedback and fail */}}
 {{- $hasBoth := false }}
-{{- range $serviceName, $service := .Values.externalServices }}
+{{- range $serviceName, $service := .Values.apiServices }}
   {{- if and $service.autoscaling.enabled (eq $service.autoscaling.type "both") }}
     {{- $hasBoth = true }}
   {{- end }}

--- a/helm-chart/eoapi/templates/services/configmap.yaml
+++ b/helm-chart/eoapi/templates/services/configmap.yaml
@@ -1,4 +1,4 @@
-{{- range $serviceName, $v := .Values.externalServices -}}
+{{- range $serviceName, $v := .Values.apiServices -}}
 {{- if index $v "enabled" }}
 apiVersion: v1
 kind: ConfigMap
@@ -11,5 +11,5 @@ data:
 ---
 {{/* END: if index $v "enabled" */}}
 {{- end }}
-{{/* END: range $serviceName, $v := .Values.externalServices */}}
+{{/* END: range $serviceName, $v := .Values.apiServices */}}
 {{- end }}

--- a/helm-chart/eoapi/templates/services/configmap.yaml
+++ b/helm-chart/eoapi/templates/services/configmap.yaml
@@ -1,5 +1,4 @@
-{{- range $serviceName, $v := .Values -}}
-{{- if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) }}
+{{- range $serviceName, $v := .Values.externalServices -}}
 {{- if index $v "enabled" }}
 apiVersion: v1
 kind: ConfigMap
@@ -12,7 +11,5 @@ data:
 ---
 {{/* END: if index $v "enabled" */}}
 {{- end }}
-{{/* END: if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) */}}
-{{- end }}
-{{/* END: range $serviceName, $v := .Values*/}}
+{{/* END: range $serviceName, $v := .Values.externalServices */}}
 {{- end }}

--- a/helm-chart/eoapi/templates/services/deployment.yaml
+++ b/helm-chart/eoapi/templates/services/deployment.yaml
@@ -1,6 +1,5 @@
 {{ include "eoapi.validateTempDB" . }}
-{{- range $serviceName, $v := .Values -}}
-{{- if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) }}
+{{- range $serviceName, $v := .Values.externalServices -}}
 {{- if index $v "enabled" }}
 apiVersion: apps/v1
 kind: Deployment
@@ -82,7 +81,5 @@ spec:
 ---
 {{/* END: if index $v "enabled" */}}
 {{- end }}
-{{/* END: if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) */}}
-{{- end }}
-{{/* END: range $serviceName, $v := .Values*/}}
+{{/* END: range $serviceName, $v := .Values.externalServices */}}
 {{- end }}

--- a/helm-chart/eoapi/templates/services/deployment.yaml
+++ b/helm-chart/eoapi/templates/services/deployment.yaml
@@ -1,5 +1,5 @@
 {{ include "eoapi.validateTempDB" . }}
-{{- range $serviceName, $v := .Values.externalServices -}}
+{{- range $serviceName, $v := .Values.apiServices -}}
 {{- if index $v "enabled" }}
 apiVersion: apps/v1
 kind: Deployment
@@ -81,5 +81,5 @@ spec:
 ---
 {{/* END: if index $v "enabled" */}}
 {{- end }}
-{{/* END: range $serviceName, $v := .Values.externalServices */}}
+{{/* END: range $serviceName, $v := .Values.apiServices */}}
 {{- end }}

--- a/helm-chart/eoapi/templates/services/hpa.yaml
+++ b/helm-chart/eoapi/templates/services/hpa.yaml
@@ -1,6 +1,5 @@
 {{- include "eoapi.validateAutoscaleRules" . -}}
-{{- range $serviceName, $v := .Values -}}
-{{- if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) }}
+{{- range $serviceName, $v := .Values.externalServices -}}
 {{- if index $v "autoscaling" "enabled" }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -43,8 +42,6 @@ spec:
   {{- end }}
 ---
 {{/* END: if index $v "autoscaling" "enabled" */}}
-{{- end }}
-{{/* END: if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) */}}
 {{- end }}
 {{/* END: range $serviceName, $v := .Values*/}}
 {{- end }}

--- a/helm-chart/eoapi/templates/services/hpa.yaml
+++ b/helm-chart/eoapi/templates/services/hpa.yaml
@@ -1,5 +1,5 @@
 {{- include "eoapi.validateAutoscaleRules" . -}}
-{{- range $serviceName, $v := .Values.externalServices -}}
+{{- range $serviceName, $v := .Values.apiServices -}}
 {{- if index $v "autoscaling" "enabled" }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/helm-chart/eoapi/templates/services/ingress-nginx.yaml
+++ b/helm-chart/eoapi/templates/services/ingress-nginx.yaml
@@ -30,8 +30,7 @@ spec:
   rules:
     - http:
         paths:
-          {{- range $serviceName, $v := .Values }}
-          {{- if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) }}
+          {{- range $serviceName, $v := .Values.externalServices }}
           {{- if (and (index $v "enabled") (not $.Values.testing)) }}
           - pathType: Prefix
             path: "/{{ $serviceName }}(/|$)(.*)"
@@ -49,8 +48,7 @@ spec:
                 port:
                   number: {{ $.Values.service.port }}
           {{- end }}{{/* END: if index $v "enabled" */}}
-          {{- end }}{{/* END: if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) */}}
-          {{- end }}{{/* END: range $serviceName, $v := .Values*/}}
+          {{- end }}{{/* END: range $serviceName, $v := .Values.externalServices */}}
           {{- if (and (not $.Values.testing) (.Values.docServer.enabled)) }}
           - pathType: Prefix
             path: /(/|$)

--- a/helm-chart/eoapi/templates/services/ingress-nginx.yaml
+++ b/helm-chart/eoapi/templates/services/ingress-nginx.yaml
@@ -30,7 +30,7 @@ spec:
   rules:
     - http:
         paths:
-          {{- range $serviceName, $v := .Values.externalServices }}
+          {{- range $serviceName, $v := .Values.apiServices }}
           {{- if (and (index $v "enabled") (not $.Values.testing)) }}
           - pathType: Prefix
             path: "/{{ $serviceName }}(/|$)(.*)"
@@ -48,7 +48,7 @@ spec:
                 port:
                   number: {{ $.Values.service.port }}
           {{- end }}{{/* END: if index $v "enabled" */}}
-          {{- end }}{{/* END: range $serviceName, $v := .Values.externalServices */}}
+          {{- end }}{{/* END: range $serviceName, $v := .Values.apiServices */}}
           {{- if (and (not $.Values.testing) (.Values.docServer.enabled)) }}
           - pathType: Prefix
             path: /(/|$)

--- a/helm-chart/eoapi/templates/services/service.yaml
+++ b/helm-chart/eoapi/templates/services/service.yaml
@@ -1,4 +1,4 @@
-{{- range $serviceName, $v := .Values.externalServices -}}
+{{- range $serviceName, $v := .Values.apiServices -}}
 {{- if index $v "enabled" }}
 apiVersion: v1
 kind: Service
@@ -27,5 +27,5 @@ spec:
 ---
 {{/* END: if index $v "enabled" */}}
 {{- end }}
-{{/* END: range $serviceName, $v := .Values.externalServices */}}
+{{/* END: range $serviceName, $v := .Values.apiServices */}}
 {{- end }}

--- a/helm-chart/eoapi/templates/services/service.yaml
+++ b/helm-chart/eoapi/templates/services/service.yaml
@@ -1,5 +1,4 @@
-{{- range $serviceName, $v := .Values -}}
-{{- if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) }}
+{{- range $serviceName, $v := .Values.externalServices -}}
 {{- if index $v "enabled" }}
 apiVersion: v1
 kind: Service
@@ -28,7 +27,5 @@ spec:
 ---
 {{/* END: if index $v "enabled" */}}
 {{- end }}
-{{/* END: if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) */}}
-{{- end }}
-{{/* END: range $serviceName, $v := .Values*/}}
+{{/* END: range $serviceName, $v := .Values.externalServices */}}
 {{- end }}

--- a/helm-chart/eoapi/tests/config_tests.yaml
+++ b/helm-chart/eoapi/tests/config_tests.yaml
@@ -4,9 +4,9 @@ templates:
 tests:
   - it: "vector configmap defaults"
     set:
-      externalServices.raster.enabled: false
-      externalServices.stac.enabled: false
-      externalServices.vector.enabled: true
+      apiServices.raster.enabled: false
+      apiServices.stac.enabled: false
+      apiServices.vector.enabled: true
     asserts:
       - isKind:
           of: ConfigMap
@@ -18,9 +18,9 @@ tests:
           value: "300"
   - it: "raster configmap defaults"
     set:
-      externalServices.raster.enabled: true
-      externalServices.stac.enabled: false
-      externalServices.vector.enabled: false
+      apiServices.raster.enabled: true
+      apiServices.stac.enabled: false
+      apiServices.vector.enabled: false
     asserts:
       - isKind:
           of: ConfigMap
@@ -32,9 +32,9 @@ tests:
           value: "YES"
   - it: "stac configmap defaults"
     set:
-      externalServices.raster.enabled: false
-      externalServices.stac.enabled: true
-      externalServices.vector.enabled: false
+      apiServices.raster.enabled: false
+      apiServices.stac.enabled: true
+      apiServices.vector.enabled: false
     asserts:
       - isKind:
           of: ConfigMap

--- a/helm-chart/eoapi/tests/config_tests.yaml
+++ b/helm-chart/eoapi/tests/config_tests.yaml
@@ -4,9 +4,9 @@ templates:
 tests:
   - it: "vector configmap defaults"
     set:
-      raster.enabled: false
-      stac.enabled: false
-      vector.enabled: true
+      externalServices.raster.enabled: false
+      externalServices.stac.enabled: false
+      externalServices.vector.enabled: true
     asserts:
       - isKind:
           of: ConfigMap
@@ -18,9 +18,9 @@ tests:
           value: "300"
   - it: "raster configmap defaults"
     set:
-      raster.enabled: true
-      stac.enabled: false
-      vector.enabled: false
+      externalServices.raster.enabled: true
+      externalServices.stac.enabled: false
+      externalServices.vector.enabled: false
     asserts:
       - isKind:
           of: ConfigMap
@@ -32,9 +32,9 @@ tests:
           value: "YES"
   - it: "stac configmap defaults"
     set:
-      raster.enabled: false
-      stac.enabled: true
-      vector.enabled: false
+      externalServices.raster.enabled: false
+      externalServices.stac.enabled: true
+      externalServices.vector.enabled: false
     asserts:
       - isKind:
           of: ConfigMap

--- a/helm-chart/eoapi/tests/deploy_tests.yaml
+++ b/helm-chart/eoapi/tests/deploy_tests.yaml
@@ -4,9 +4,9 @@ templates:
 tests:
   - it: "vector deploy defaults"
     set:
-      externalServices.raster.enabled: false
-      externalServices.stac.enabled: false
-      externalServices.vector.enabled: true
+      apiServices.raster.enabled: false
+      apiServices.stac.enabled: false
+      apiServices.vector.enabled: true
     asserts:
       - isKind:
           of: Deployment
@@ -33,9 +33,9 @@ tests:
           value: "ABC123"
   - it: "raster deploy defaults"
     set:
-      externalServices.raster.enabled: true
-      externalServices.stac.enabled: false
-      externalServices.vector.enabled: false
+      apiServices.raster.enabled: true
+      apiServices.stac.enabled: false
+      apiServices.vector.enabled: false
     asserts:
       - isKind:
           of: Deployment
@@ -62,9 +62,9 @@ tests:
           value: "ABC123"
   - it: "stac deploy defaults"
     set:
-      externalServices.raster.enabled: false
-      externalServices.stac.enabled: true
-      externalServices.vector.enabled: false
+      apiServices.raster.enabled: false
+      apiServices.stac.enabled: true
+      apiServices.vector.enabled: false
     asserts:
       - isKind:
           of: Deployment

--- a/helm-chart/eoapi/tests/deploy_tests.yaml
+++ b/helm-chart/eoapi/tests/deploy_tests.yaml
@@ -4,9 +4,9 @@ templates:
 tests:
   - it: "vector deploy defaults"
     set:
-      raster.enabled: false
-      stac.enabled: false
-      vector.enabled: true
+      externalServices.raster.enabled: false
+      externalServices.stac.enabled: false
+      externalServices.vector.enabled: true
     asserts:
       - isKind:
           of: Deployment
@@ -33,9 +33,9 @@ tests:
           value: "ABC123"
   - it: "raster deploy defaults"
     set:
-      raster.enabled: true
-      stac.enabled: false
-      vector.enabled: false
+      externalServices.raster.enabled: true
+      externalServices.stac.enabled: false
+      externalServices.vector.enabled: false
     asserts:
       - isKind:
           of: Deployment
@@ -62,9 +62,9 @@ tests:
           value: "ABC123"
   - it: "stac deploy defaults"
     set:
-      raster.enabled: false
-      stac.enabled: true
-      vector.enabled: false
+      externalServices.raster.enabled: false
+      externalServices.stac.enabled: true
+      externalServices.vector.enabled: false
     asserts:
       - isKind:
           of: Deployment

--- a/helm-chart/eoapi/tests/hpa_tests.yaml
+++ b/helm-chart/eoapi/tests/hpa_tests.yaml
@@ -4,13 +4,12 @@ templates:
 tests:
   - it: "vector hpa fail for requestRate"
     set:
-      raster.enabled: false
-      stac.enabled: false
-      vector.enabled: true
+      externalServices.raster.enabled: false
+      externalServices.stac.enabled: false
+      externalServices.vector.enabled: true
       ingress.className: "testing123"
-      vector.autoscaling.enabled: true
-      vector.autoscaling.type: "requestRate"
+      externalServices.vector.autoscaling.enabled: true
+      externalServices.vector.autoscaling.type: "requestRate"
     asserts:
       - failedTemplate:
           errorMessage: When using an 'ingress.className' other than 'nginx' you cannot enable autoscaling by 'requestRate' at this time b/c it's solely an nginx metric
-

--- a/helm-chart/eoapi/tests/hpa_tests.yaml
+++ b/helm-chart/eoapi/tests/hpa_tests.yaml
@@ -4,12 +4,12 @@ templates:
 tests:
   - it: "vector hpa fail for requestRate"
     set:
-      externalServices.raster.enabled: false
-      externalServices.stac.enabled: false
-      externalServices.vector.enabled: true
+      apiServices.raster.enabled: false
+      apiServices.stac.enabled: false
+      apiServices.vector.enabled: true
       ingress.className: "testing123"
-      externalServices.vector.autoscaling.enabled: true
-      externalServices.vector.autoscaling.type: "requestRate"
+      apiServices.vector.autoscaling.enabled: true
+      apiServices.vector.autoscaling.type: "requestRate"
     asserts:
       - failedTemplate:
           errorMessage: When using an 'ingress.className' other than 'nginx' you cannot enable autoscaling by 'requestRate' at this time b/c it's solely an nginx metric

--- a/helm-chart/eoapi/tests/ingress_tests_nginx.yaml
+++ b/helm-chart/eoapi/tests/ingress_tests_nginx.yaml
@@ -4,10 +4,10 @@ templates:
 tests:
   - it: "vector ingress defaults"
     set:
-      ingress.className: "nginx"
-      raster.enabled: false
-      stac.enabled: false
-      vector.enabled: true
+      externalServices.ingress.className: "nginx"
+      externalServices.raster.enabled: false
+      externalServices.stac.enabled: false
+      externalServices.vector.enabled: true
     asserts:
       - isKind:
           of: Ingress
@@ -26,10 +26,10 @@ tests:
           value: "nginx"
   - it: "raster ingress defaults"
     set:
-      ingress.className: "nginx"
-      raster.enabled: true
-      stac.enabled: false
-      vector.enabled: false
+      externalServices.ingress.className: "nginx"
+      externalServices.raster.enabled: true
+      externalServices.stac.enabled: false
+      externalServices.vector.enabled: false
     asserts:
       - isKind:
           of: Ingress
@@ -48,10 +48,10 @@ tests:
           value: "nginx"
   - it: "stac ingress defaults"
     set:
-      ingress.className: "nginx"
-      raster.enabled: false
-      stac.enabled: true
-      vector.enabled: false
+      externalServices.ingress.className: "nginx"
+      externalServices.raster.enabled: false
+      externalServices.stac.enabled: true
+      externalServices.vector.enabled: false
     asserts:
       - isKind:
           of: Ingress

--- a/helm-chart/eoapi/tests/ingress_tests_nginx.yaml
+++ b/helm-chart/eoapi/tests/ingress_tests_nginx.yaml
@@ -4,10 +4,10 @@ templates:
 tests:
   - it: "vector ingress defaults"
     set:
-      externalServices.ingress.className: "nginx"
-      externalServices.raster.enabled: false
-      externalServices.stac.enabled: false
-      externalServices.vector.enabled: true
+      apiServices.ingress.className: "nginx"
+      apiServices.raster.enabled: false
+      apiServices.stac.enabled: false
+      apiServices.vector.enabled: true
     asserts:
       - isKind:
           of: Ingress
@@ -26,10 +26,10 @@ tests:
           value: "nginx"
   - it: "raster ingress defaults"
     set:
-      externalServices.ingress.className: "nginx"
-      externalServices.raster.enabled: true
-      externalServices.stac.enabled: false
-      externalServices.vector.enabled: false
+      apiServices.ingress.className: "nginx"
+      apiServices.raster.enabled: true
+      apiServices.stac.enabled: false
+      apiServices.vector.enabled: false
     asserts:
       - isKind:
           of: Ingress
@@ -48,10 +48,10 @@ tests:
           value: "nginx"
   - it: "stac ingress defaults"
     set:
-      externalServices.ingress.className: "nginx"
-      externalServices.raster.enabled: false
-      externalServices.stac.enabled: true
-      externalServices.vector.enabled: false
+      apiServices.ingress.className: "nginx"
+      apiServices.raster.enabled: false
+      apiServices.stac.enabled: true
+      apiServices.vector.enabled: false
     asserts:
       - isKind:
           of: Ingress

--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -170,169 +170,171 @@ pgstacBootstrap:
 ######################
 # API SERVICES
 ######################
-raster:
-  enabled: true
-  autoscaling:
-    # NOTE: to have autoscaling working you'll need to install the `eoapi-support` chart
-    # see ../../../docs/autoscaling.md for more information
-    enabled: false
-    minReplicas: 1
-    maxReplicas: 10
-    # `type`: "cpu" || "requestRate" || "both"
-    type: "requestRate"
-    behaviour:
-      scaleDown:
-        stabilizationWindowSeconds: 60
-      scaleUp:
-        stabilizationWindowSeconds: 0
-    targets:
-      # matches `type` value above unless `type: "both"` is selected
-      cpu: 75
-      # 'm' units here represents generic milli (one-thousandth) unit instead of 'decimal'
-      # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#quantities
-      # so when the average unit among these pods is <requestRate>/1000 then scale
-      # you can watch the actual/target in real time using `kubectl get hpa/<name>`
-      requestRate: 100000m
-  image:
-    name: ghcr.io/stac-utils/titiler-pgstac
-    tag: uvicorn-1.4.0
-  command:
-    - "uvicorn"
-    - "titiler.pgstac.main:app"
-    - "--host=$(HOST)"
-    - "--port=$(PORT)"
-  settings:
-    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-    resources:
-      limits:
-        cpu: "768m"
-        memory: "4096Mi"
-      requests:
-        cpu: "256m"
-        memory: "3072Mi"
-    envVars:
-      ##############
-      # titiler
-      ##############
-      GDAL_CACHEMAX: "200"  # 200 mb
-      GDAL_DISABLE_READDIR_ON_OPEN: "EMPTY_DIR"
-      GDAL_INGESTED_BYTES_AT_OPEN: "32768"
-      GDAL_HTTP_MERGE_CONSECUTIVE_RANGES: "YES"
-      GDAL_HTTP_MULTIPLEX: "YES"
-      GDAL_HTTP_VERSION: "2"
-      PYTHONWARNINGS: "ignore"
-      VSI_CACHE: "TRUE"
-      VSI_CACHE_SIZE: "5000000"  # 5 MB (per file-handle)
-      ##############
-      # uvicorn
-      ##############
-      HOST: "0.0.0.0"
-      PORT: "8080"
-      # https://www.uvicorn.org/settings/#production
-      WEB_CONCURRENCY: "5"
 
-stac:
-  enabled: true
-  autoscaling:
-    # NOTE: to have autoscaling working you'll need to install the `eoapi-support` chart
-    # see ../../../docs/autoscaling.md for more information
-    enabled: false
-    minReplicas: 1
-    maxReplicas: 10
-    # `type`: "cpu" || "requestRate" || "both"
-    type: "requestRate"
-    behaviour:
-      scaleDown:
-        stabilizationWindowSeconds: 60
-      scaleUp:
-        stabilizationWindowSeconds: 0
-    targets:
-      # matches `type` value above unless `type: "both"` is selected
-      cpu: 75
-      # 'm' units here represents generic milli (one-thousandth) unit instead of 'decimal'
-      # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#quantities
-      # so when the average unit among these pods is <requestRate>/1000 then scale
-      # you can watch the actual/target in real time using `kubectl get hpa/<name>`
-      requestRate: 100000m
-  image:
-    name: ghcr.io/stac-utils/stac-fastapi-pgstac
-    tag: 2.4.9
-  command:
-    - "uvicorn"
-    - "stac_fastapi.pgstac.app:app"
-    - "--host=$(HOST)"
-    - "--port=$(PORT)"
-  settings:
-    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-    resources:
-      limits:
-        cpu: "768m"
-        memory: "1024Mi"
-      requests:
-        cpu: "256m"
-        memory: "1024Mi"
-    envVars:
-      ##############
-      # uvicorn
-      ##############
-      HOST: "0.0.0.0"
-      PORT: "8080"
-      # https://www.uvicorn.org/settings/#production
-      WEB_CONCURRENCY: "5"
+externalServices:
+  raster:
+    enabled: true
+    autoscaling:
+      # NOTE: to have autoscaling working you'll need to install the `eoapi-support` chart
+      # see ../../../docs/autoscaling.md for more information
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 10
+      # `type`: "cpu" || "requestRate" || "both"
+      type: "requestRate"
+      behaviour:
+        scaleDown:
+          stabilizationWindowSeconds: 60
+        scaleUp:
+          stabilizationWindowSeconds: 0
+      targets:
+        # matches `type` value above unless `type: "both"` is selected
+        cpu: 75
+        # 'm' units here represents generic milli (one-thousandth) unit instead of 'decimal'
+        # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#quantities
+        # so when the average unit among these pods is <requestRate>/1000 then scale
+        # you can watch the actual/target in real time using `kubectl get hpa/<name>`
+        requestRate: 100000m
+    image:
+      name: ghcr.io/stac-utils/titiler-pgstac
+      tag: uvicorn-1.4.0
+    command:
+      - "uvicorn"
+      - "titiler.pgstac.main:app"
+      - "--host=$(HOST)"
+      - "--port=$(PORT)"
+    settings:
+      # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+      resources:
+        limits:
+          cpu: "768m"
+          memory: "4096Mi"
+        requests:
+          cpu: "256m"
+          memory: "3072Mi"
+      envVars:
+        ##############
+        # titiler
+        ##############
+        GDAL_CACHEMAX: "200"  # 200 mb
+        GDAL_DISABLE_READDIR_ON_OPEN: "EMPTY_DIR"
+        GDAL_INGESTED_BYTES_AT_OPEN: "32768"
+        GDAL_HTTP_MERGE_CONSECUTIVE_RANGES: "YES"
+        GDAL_HTTP_MULTIPLEX: "YES"
+        GDAL_HTTP_VERSION: "2"
+        PYTHONWARNINGS: "ignore"
+        VSI_CACHE: "TRUE"
+        VSI_CACHE_SIZE: "5000000"  # 5 MB (per file-handle)
+        ##############
+        # uvicorn
+        ##############
+        HOST: "0.0.0.0"
+        PORT: "8080"
+        # https://www.uvicorn.org/settings/#production
+        WEB_CONCURRENCY: "5"
 
-vector:
-  enabled: true
-  autoscaling:
-    # NOTE: to have autoscaling working you'll need to install the `eoapi-support` chart
-    # see ../../../docs/autoscaling.md for more information
-    enabled: false
-    minReplicas: 1
-    maxReplicas: 10
-    # `type`: "cpu" || "requestRate" || "both"
-    type: "requestRate"
-    behaviour:
-      scaleDown:
-        stabilizationWindowSeconds: 60
-      scaleUp:
-        stabilizationWindowSeconds: 0
-    targets:
-      # matches `type` value above unless `type: "both"` is selected
-      cpu: 75
-      # 'm' units here represents generic milli (one-thousandth) unit instead of 'decimal'
-      # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#quantities
-      # so when the average unit among these pods is <requestRate>/1000 then scale
-      # you can watch the actual/target in real time using `kubectl get hpa/<name>`
-      requestRate: 100000m
-  image:
-    name: ghcr.io/developmentseed/tipg
-    tag: uvicorn-0.6.1
-  command:
-    - "uvicorn"
-    - "tipg.main:app"
-    - "--host=$(HOST)"
-    - "--port=$(PORT)"
-  settings:
-    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-    resources:
-      limits:
-        cpu: "768m"
-        memory: "1024Mi"
-      requests:
-        cpu: "256m"
-        memory: "256Mi"
-    envVars:
-      ##############
-      # tipg
-      ##############
-      TIPG_CATALOG_TTL: "300"
-      TIPG_DEBUG: "True"
-      ##############
-      # uvicorn
-      ##############
-      HOST: "0.0.0.0"
-      PORT: "8080"
-      # https://www.uvicorn.org/settings/#production
-      WEB_CONCURRENCY: "5"
+  stac:
+    enabled: true
+    autoscaling:
+      # NOTE: to have autoscaling working you'll need to install the `eoapi-support` chart
+      # see ../../../docs/autoscaling.md for more information
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 10
+      # `type`: "cpu" || "requestRate" || "both"
+      type: "requestRate"
+      behaviour:
+        scaleDown:
+          stabilizationWindowSeconds: 60
+        scaleUp:
+          stabilizationWindowSeconds: 0
+      targets:
+        # matches `type` value above unless `type: "both"` is selected
+        cpu: 75
+        # 'm' units here represents generic milli (one-thousandth) unit instead of 'decimal'
+        # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#quantities
+        # so when the average unit among these pods is <requestRate>/1000 then scale
+        # you can watch the actual/target in real time using `kubectl get hpa/<name>`
+        requestRate: 100000m
+    image:
+      name: ghcr.io/stac-utils/stac-fastapi-pgstac
+      tag: 2.4.9
+    command:
+      - "uvicorn"
+      - "stac_fastapi.pgstac.app:app"
+      - "--host=$(HOST)"
+      - "--port=$(PORT)"
+    settings:
+      # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+      resources:
+        limits:
+          cpu: "768m"
+          memory: "1024Mi"
+        requests:
+          cpu: "256m"
+          memory: "1024Mi"
+      envVars:
+        ##############
+        # uvicorn
+        ##############
+        HOST: "0.0.0.0"
+        PORT: "8080"
+        # https://www.uvicorn.org/settings/#production
+        WEB_CONCURRENCY: "5"
+
+  vector:
+    enabled: true
+    autoscaling:
+      # NOTE: to have autoscaling working you'll need to install the `eoapi-support` chart
+      # see ../../../docs/autoscaling.md for more information
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 10
+      # `type`: "cpu" || "requestRate" || "both"
+      type: "requestRate"
+      behaviour:
+        scaleDown:
+          stabilizationWindowSeconds: 60
+        scaleUp:
+          stabilizationWindowSeconds: 0
+      targets:
+        # matches `type` value above unless `type: "both"` is selected
+        cpu: 75
+        # 'm' units here represents generic milli (one-thousandth) unit instead of 'decimal'
+        # https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#quantities
+        # so when the average unit among these pods is <requestRate>/1000 then scale
+        # you can watch the actual/target in real time using `kubectl get hpa/<name>`
+        requestRate: 100000m
+    image:
+      name: ghcr.io/developmentseed/tipg
+      tag: uvicorn-0.6.1
+    command:
+      - "uvicorn"
+      - "tipg.main:app"
+      - "--host=$(HOST)"
+      - "--port=$(PORT)"
+    settings:
+      # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+      resources:
+        limits:
+          cpu: "768m"
+          memory: "1024Mi"
+        requests:
+          cpu: "256m"
+          memory: "256Mi"
+      envVars:
+        ##############
+        # tipg
+        ##############
+        TIPG_CATALOG_TTL: "300"
+        TIPG_DEBUG: "True"
+        ##############
+        # uvicorn
+        ##############
+        HOST: "0.0.0.0"
+        PORT: "8080"
+        # https://www.uvicorn.org/settings/#production
+        WEB_CONCURRENCY: "5"
 
 docServer:
   enabled: true

--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -171,7 +171,7 @@ pgstacBootstrap:
 # API SERVICES
 ######################
 
-externalServices:
+apiServices:
   raster:
     enabled: true
     autoscaling:


### PR DESCRIPTION
This PR proposes encapsulating the external services—`stac`, `raster`, and `vector`—within an `externalServices` structure. This enhancement enables subcharts to extend these services, facilitating the injection of additional external services, such as an application frontend.

Involved in this PR @ciaransweet and @emmanuelmathot during our pod week.