### PR TITLE
fix(support): Add passthrough for ca bundle secret into metrics server

### DIFF
--- a/helm-chart/eoapi-support/templates/_helpers.tpl
+++ b/helm-chart/eoapi-support/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/*
+Fetch the CA Bundle from a specified secret if enabled
+*/}}
+{{- define "eoapi-support.fetchCaBundle" -}}
+{{- if .Values.enableCaBundleFetch -}}
+  {{- $secretName := .Values.caBundleSecretName | default "eoepca-ca-secret" -}}
+  {{- $caBundle := "" -}}
+  {{- with (lookup "v1" "Secret" "default" $secretName) -}}
+    {{- $caBundle = index .data "ca.crt" | b64dec -}}
+  {{- end -}}
+  {{- $caBundle -}}
+{{- else -}}
+  ""  # Return an empty string if not enabled
+{{- end -}}
+{{- end -}}

--- a/helm-chart/eoapi-support/values.yaml
+++ b/helm-chart/eoapi-support/values.yaml
@@ -1,3 +1,8 @@
+# when enabled, metrics-server will use the caBundle from the provided secret
+# ref: https://github.com/developmentseed/eoapi-k8s/issues/154
+enableCaBundleFetch: false
+caBundleSecretName: ""
+
 # most of this was cribbed from https://github.com/2i2c-org/infrastructure/blob/master/helm-charts/support/
 # so giving props where props are due to Yuvi Panda :sparkles:
 prometheus-adapter:
@@ -162,7 +167,6 @@ grafana:
 
   dashboardsConfigMaps:
     default: "eoapi-dashboards"
-
 
 metrics-server:
   apiService:


### PR DESCRIPTION
Trying something to address https://github.com/developmentseed/eoapi-k8s/issues/154 by allowing a caBundle to be generated on install from an existing secret. Requires the cert manager to be pre-deployed to the cluster. Might be a niche use case (and also might not work - did some testing locally but not in a production environment with a fully-configured cert manager).

I need to get this released to test properly, but will keep this PR as a breadcrumb for future reference.