### PR TITLE
Allow additional secrets to set environment variables

### DIFF
--- a/helm-chart/eoapi/Chart.yaml
+++ b/helm-chart/eoapi/Chart.yaml
@@ -15,7 +15,7 @@ kubeVersion: ">=1.23.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.5.0"
+version: "0.5.2"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-chart/eoapi/templates/services/deployment.yaml
+++ b/helm-chart/eoapi/templates/services/deployment.yaml
@@ -65,6 +65,12 @@ spec:
         - secretRef:
             name: pgstac-secrets-{{ $.Release.Name }}
         {{- end }}
+        {{- if index $v "settings" "envSecrets" }}
+        {{- range $secret := index $v "settings" "envSecrets" }}
+        - secretRef:
+            name: {{ $secret }}
+        {{- end }}
+        {{- end }}
 ---
 {{/* END: if index $v "enabled" */}}
 {{- end }}


### PR DESCRIPTION
Currently, the `envVars` for eoapi allow setting of environment variables as a string. However these values might be set in some kubernetes secret. Let's extend eoAPI to handle those cases.