### PR TITLE
feat: Add stac-browser

### DIFF
--- a/helm-chart/eoapi/templates/services/nginx-doc-server.yaml
+++ b/helm-chart/eoapi/templates/services/nginx-doc-server.yaml
@@ -16,6 +16,7 @@ data:
           <li><a href="/raster" target="_blank" rel="noopener noreferrer">/raster</a></li>
           <li><a href="/vector" target="_blank" rel="noopener noreferrer">/vector</a></li>
           <li><a href="/stac" target="_blank" rel="noopener noreferrer">/stac</a></li>
+          <li><a href="/browser/" target="_blank" rel="noopener noreferrer">/browser</a></li>
         </ul>
     </body>
     </html>

--- a/helm-chart/eoapi/templates/services/stac-browser.yaml
+++ b/helm-chart/eoapi/templates/services/stac-browser.yaml
@@ -1,0 +1,59 @@
+{{- if (and (.Values.browser.enabled) (not .Values.testing)  (.Values.docServer.enabled))}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: browser-{{ .Release.Name }}
+spec:
+  replicas: {{.Values.browser.replicaCount}}
+  selector:
+    matchLabels:
+      app: browser-{{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: browser-{{ .Release.Name }}
+    spec:
+      containers:
+        - name: browser
+          image: {{ .Values.browser.image.name }}:{{ .Values.browser.image.tag }}
+          ports:
+          - containerPort: 8080
+          env:
+            - name: SB_catalogUrl
+              value: "/stac"
+            - name: SB_prefixPath
+              value: "/browser"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: browser-{{ .Release.Name }}
+spec:
+  selector:
+    app: browser-{{ .Release.Name }}
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+---
+# We need a separate ingress because browser does not play well with nginx rewrite_path directive
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: stac-browser-ingress
+spec:
+  {{- if (and (.Values.ingress.className) (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion)) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    - http:
+        paths:
+        - pathType: Prefix
+          path: "/browser"
+          backend:
+            service:
+              name: browser-{{ $.Release.Name }}
+              port:
+                number: 8080
+
+{{- end }}

--- a/helm-chart/eoapi/templates/services/traefik-doc-server.yaml
+++ b/helm-chart/eoapi/templates/services/traefik-doc-server.yaml
@@ -16,6 +16,7 @@ data:
           <li><a href="/raster" target="_blank" rel="noopener noreferrer">/raster</a></li>
           <li><a href="/vector" target="_blank" rel="noopener noreferrer">/vector</a></li>
           <li><a href="/stac" target="_blank" rel="noopener noreferrer">/stac</a></li>
+          <li><a href="/browser/" target="_blank" rel="noopener noreferrer">/browser</a></li>
         </ul>
     </body>
     </html>

--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -334,5 +334,18 @@ vector:
       # https://www.uvicorn.org/settings/#production
       WEB_CONCURRENCY: "5"
 
+######################
+# STAC Browser
+######################
+# It is a good idea to deploy stac-browser outside of k8s, since it's SPA with static files.
+# Please consider alternatives, such as cloud storage + CDN, for example 
+browser:
+  enabled: true
+  replicaCount: 1
+  image:
+    # we use a custom image that overrides pathPrefix value
+    name: ghcr.io/alekzvik/stac-browser-prefix
+    tag: 3.2.0
+
 docServer:
   enabled: true

--- a/ingest.sh
+++ b/ingest.sh
@@ -17,7 +17,7 @@ else
 fi
 
 # Define namespaces
-NAMESPACES=("default" "eoapi", "data-access")
+NAMESPACES=("default" "eoapi" "data-access")
 EOAPI_POD_RASTER=""
 FOUND_NAMESPACE=""
 


### PR DESCRIPTION
## What I am changing
I am adding a STAC Browser as an additional service.

## How I did it
I am using a custom image due to complications described [here](https://github.com/developmentseed/eoapi-k8s/issues/62#issuecomment-2229099746)
The custom image is built on CRON once daily if there are changes.

## Alternatives
Another alternative is to avoid a custom image and do all the work in the `initContainer`. We spawn an `initContainer` with `node` that checks out the git repo on a tag, installs dependencies, builds the `stac-browser`, and puts the static files in a shared volume. The main container would be nginx which serves the data from the mounted volume.
Pros:
- it is less dependent on another repo doing trickery in its actions
- it can be much more configurable

Cons:
- this approach is much slower. The `npm install` & `npm build` take a long time

## Notes
1. The whole approach to the STAC browser is not ideal. I mentioned in `values.yaml` that the preferred way to deploy the STAC browser would not be with k8s&helm, but maybe there is a better way to convey this to users.
2. There are problems with `/browser` URL routing (without the trailing slash) and I have not identified the source yet.
3. The URL is persisted in a way that does not allow to recover state. If you open a collection -> item and then reload the page, stac browser fails to recover the state.

## How you can test it
`helm update --install ...` and one more service appears in the list of static services.
The URL is `/browser/`, it will point to the stac endpoint exposed at `/stac`

## Related Issues
Closes #62 
