### PR TITLE
Allow Repeated Helm Deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ all: deploy
 deploy:
 	@echo "Installing dependencies."
 	@command -v helm >/dev/null 2>&1 || { echo "helm is required but not installed"; exit 1; }
-	helm install --set disable_check_for_upgrades=true pgo oci://registry.developers.crunchydata.com/crunchydata/pgo --version $(PGO_CHART_VERSION)
+	helm upgrade --install --set disable_check_for_upgrades=true pgo oci://registry.developers.crunchydata.com/crunchydata/pgo --version $(PGO_CHART_VERSION)
 	@echo "Adding eoAPI helm repository."
 	@helm repo add eoapi $(HELM_REPO_URL)
 	@echo "Installing eoAPI helm chart."
 	@cd ./helm-chart && \
 	helm dependency build ./eoapi && \
-	helm install --namespace eoapi --create-namespace --set gitSha=$$(git rev-parse HEAD | cut -c1-10) eoapi ./eoapi
+	helm upgrade --install --namespace eoapi --create-namespace --set gitSha=$$(git rev-parse HEAD | cut -c1-10) eoapi ./eoapi
 
 minikube:
 	@echo "Starting minikube."


### PR DESCRIPTION
A simple quality of life change: Using `helm upgrade --install` allows `make deploy` to be run multiple times as changes are made locally.

## What I am changing
<!-- What were the high-level goals of the change? -->
- Using `helm install` in the makefile prevents one from running `make deploy` multiple times (helm install fails if the release already exists)
- This makes it difficult to iterate or experiment locally, e.g. to tweak `envVars` or add to `initdb-data`

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Switching to `helm upgrade --install` will upgrade an existing helm release or install it if it does not yet exist
- See: https://helm.sh/docs/helm/helm_upgrade/

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Run `make deploy` or `make minikube` to install the system into a k8s cluster
- Make a local change, e.g. update an `envVar` in `#helm-chart/values.yaml`
- Run `make deploy` or `make minikube` again
- The resources of the helm release should be updated without error

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- N/A
