### PR TITLE
Use template functions to quote env vars

### DIFF
--- a/helm-chart/eoapi/templates/services/configmap.yaml
+++ b/helm-chart/eoapi/templates/services/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ $serviceName }}-envvar-configmap-{{ $.Release.Name }}
 data:
   {{- range $envKey, $envValue := index $v "settings" "envVars" }}
-  {{ upper $envKey }}: "{{ $envValue }}"
+  {{ upper $envKey }}: {{ $envValue | quote }}
   {{- end }}
 ---
 {{/* END: if index $v "enabled" */}}


### PR DESCRIPTION
This allows helm to intelligently quote env var values, e.g. in order to pass json arrays as values

## What I am changing
<!-- What were the high-level goals of the change? -->
- The way that helm-chart/eoapi/templates/services/configmap.yaml was rendering `envValues` prevented it from handling strings representing JSON arrays, which are used in several places for eoapi services.
- For example, setting `TIPG_DB_SCHEMAS: '["public", "pgstac"]'` as described [in the docs](https://developmentseed.org/tipg/user_guide/configuration/#db-visibility-settings) results in:
    - `Error: UPGRADE FAILED: YAML parse error on eoapi/templates/services/configmap.yaml: error converting YAML to JSON: yaml: line 8: did not find expected key`

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Using the builtin `quote` template function intelligently quotes input strings to prevent repeated, unescaped double-quotes

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Set `TIPG_DB_SCHEMAS: '["public", "pgstac"]'` in `values.yaml` under `vector.settings.envVars` and run `make deploy`

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- N/A
