### PR TITLE
Tolerations and affinity

### DIFF
--- a/helm-chart/eoapi/templates/pgstacboostrap/job.yaml
+++ b/helm-chart/eoapi/templates/pgstacboostrap/job.yaml
@@ -51,5 +51,13 @@ spec:
         - name: pgstac-setup-volume-{{ $.Release.Name }}
           configMap:
             name: pgstac-setup-config-{{ $.Release.Name }}
+      {{- with .Values.pgstacBootstrap.settings.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pgstacBootstrap.settings.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   backoffLimit: 1
 {{- end }}

--- a/helm-chart/eoapi/templates/services/deployment.yaml
+++ b/helm-chart/eoapi/templates/services/deployment.yaml
@@ -71,6 +71,14 @@ spec:
             name: {{ $secret }}
         {{- end }}
         {{- end }}
+      {{- with index $v "settings" "affinity" }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with index $v "settings" "tolerations" }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 {{/* END: if index $v "enabled" */}}
 {{- end }}

--- a/helm-chart/eoapi/templates/services/nginx-doc-server.yaml
+++ b/helm-chart/eoapi/templates/services/nginx-doc-server.yaml
@@ -46,6 +46,14 @@ spec:
       - name: doc-html-{{ .Release.Name }}
         configMap:
           name: nginx-root-html-{{ .Release.Name }}
+      {{- with .Values.docServer.settings.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.docServer.settings.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -165,6 +165,8 @@ pgstacBootstrap:
       LOAD_FIXTURES: "true"
       # toggle to `true` if you want to keep the job running as db jumpbox
       KEEP_ALIVE: "false"
+    affinity: {}
+    tolerations: []
 
 
 ######################
@@ -230,6 +232,8 @@ raster:
       PORT: "8080"
       # https://www.uvicorn.org/settings/#production
       WEB_CONCURRENCY: "5"
+    affinity: {}
+    tolerations: []
 
 stac:
   enabled: true
@@ -279,6 +283,8 @@ stac:
       PORT: "8080"
       # https://www.uvicorn.org/settings/#production
       WEB_CONCURRENCY: "5"
+    affinity: {}
+    tolerations: []
 
 vector:
   enabled: true
@@ -333,6 +339,11 @@ vector:
       PORT: "8080"
       # https://www.uvicorn.org/settings/#production
       WEB_CONCURRENCY: "5"
+    affinity: {}
+    tolerations: []
 
 docServer:
   enabled: true
+  settings:
+    affinity: {}
+    tolerations: []

--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -341,8 +341,6 @@ vector:
       PORT: "8080"
       # https://www.uvicorn.org/settings/#production
       WEB_CONCURRENCY: "5"
-    affinity: {}
-    tolerations: []
 
 docServer:
   enabled: true

--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -108,8 +108,6 @@ postgrescluster:
   instances:
   - name: eoapi
     replicas: 1
-    affinity: {}
-    tolerations: []
     dataVolumeClaimSpec:
       accessModes:
       - "ReadWriteOnce"

--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -232,8 +232,6 @@ raster:
       PORT: "8080"
       # https://www.uvicorn.org/settings/#production
       WEB_CONCURRENCY: "5"
-    affinity: {}
-    tolerations: []
 
 stac:
   enabled: true

--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -283,8 +283,6 @@ stac:
       PORT: "8080"
       # https://www.uvicorn.org/settings/#production
       WEB_CONCURRENCY: "5"
-    affinity: {}
-    tolerations: []
 
 vector:
   enabled: true

--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -167,8 +167,6 @@ pgstacBootstrap:
       LOAD_FIXTURES: "true"
       # toggle to `true` if you want to keep the job running as db jumpbox
       KEEP_ALIVE: "false"
-    affinity: {}
-    tolerations: []
 
 
 ######################

--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -108,6 +108,8 @@ postgrescluster:
   instances:
   - name: eoapi
     replicas: 1
+    affinity: {}
+    tolerations: []
     dataVolumeClaimSpec:
       accessModes:
       - "ReadWriteOnce"

--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -346,6 +346,3 @@ vector:
 
 docServer:
   enabled: true
-  settings:
-    affinity: {}
-    tolerations: []


### PR DESCRIPTION
This PR adds tolerations and affinity settings for all pods. This is necessary for clusters with multiple node types, where the operators want to run eoapi on specific ones.

I've tested the change with the following values. With this all pods run on the desired nodes (except for pgbounce and pgbackuprest, but these can be [configured by using `postgrescluster` values](https://access.crunchydata.com/documentation/postgres-operator/latest/references/crd/5.7.x/postgrescluster#postgresclusterspecproxypgbounceraffinity)).

The values are a bit repetitive, but it might be a realistic use case that e.g. titiler should run on specific nodes, which would not be possible with a global tolerations/affinity setting (although it would be enough for my use case for now).

I'm not sure if these settings can realistically be tested in CI in k3s. We'd need to have different nodes in k3s and make sure that the services are spawned in the correct ones.

Related discussion: https://github.com/developmentseed/eoapi-k8s/discussions/172

```
stac:
  settings:
    affinity:
      nodeAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
          nodeSelectorTerms:
          - matchExpressions:
            - key: "my-node-key"
              operator: In
              values:
              - user
    tolerations:
      - key: "my-taint-name"
        operator: "Equal"
        value: "user"
        effect: "NoSchedule"

raster:
  settings:
    affinity:
      nodeAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
          nodeSelectorTerms:
          - matchExpressions:
            - key: "my-node-key"
              operator: In
              values:
              - user
    tolerations:
      - key: "my-taint-name"
        operator: "Equal"
        value: "user"
        effect: "NoSchedule"

vector:
  settings:
    affinity:
      nodeAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
          nodeSelectorTerms:
          - matchExpressions:
            - key: "my-node-key"
              operator: In
              values:
              - user
    tolerations:
      - key: "my-taint-name"
        operator: "Equal"
        value: "user"
        effect: "NoSchedule"

docServer:
  settings:
    affinity:
      nodeAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
          nodeSelectorTerms:
          - matchExpressions:
            - key: "my-node-key"
              operator: In
              values:
              - user
    tolerations:
      - key: "my-taint-name"
        operator: "Equal"
        value: "user"
        effect: "NoSchedule"

pgstacBootstrap:
  settings:
    affinity:
      nodeAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
          nodeSelectorTerms:
          - matchExpressions:
            - key: "my-node-key"
              operator: In
              values:
              - user
    tolerations:
      - key: "my-taint-name"
        operator: "Equal"
        value: "user"
        effect: "NoSchedule"

postgrescluster:
  instances:
  - name: eoapi
    replicas: 1
    affinity: 
      nodeAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
          nodeSelectorTerms:
          - matchExpressions:
            - key: "my-node-key"
              operator: In
              values:
              - user

    tolerations: 
    - key: "my-taint-name"
      operator: "Equal"
      value: "user"
      effect: "NoSchedule"

    dataVolumeClaimSpec:
      accessModes:
      - "ReadWriteOnce"
      resources:
        requests:
          storage: "10Gi"
          cpu: "1024m"
          memory: "3048Mi"
```