### PR TITLE
Allow setting annotations for deployments

### DIFF
--- a/helm-chart/eoapi/templates/services/deployment.yaml
+++ b/helm-chart/eoapi/templates/services/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     app: {{ $serviceName }}-{{ $.Release.Name }}
     gitsha: {{ $.Values.gitSha }}
   name: {{ $serviceName }}-{{ $.Release.Name }}
+  {{- with index $v "annotations" }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   progressDeadlineSeconds: 600
   revisionHistoryLimit: 5


### PR DESCRIPTION
This change basically forwards `raster-eoapi.annotations` to the annotations of the respective deployment. There are no official guidelines on key structuring, but this follows conventions set [by other large charts](https://artifacthub.io/packages/helm/grafana/grafana) where properties on the top level object are forwarded to the central kubernetes object, in this case the deployment.

Other objects could still be customized with sub-keys, e.g. `raster-eoapi.service.annotations` could be applied to the respective kubernetes service.

The values currently also contain a `settings` key. Since properties like `image` or `command` are configured directly in `raster-eoapi`, I've also placed the annotations directly here. However they could also be moved to `settings`.

Related discussion: https://github.com/developmentseed/eoapi-k8s/discussions/172