### PR TITLE
Fix helm template error if docServer settings is not defined

### DIFF
--- a/helm-chart/eoapi/templates/services/nginx-doc-server.yaml
+++ b/helm-chart/eoapi/templates/services/nginx-doc-server.yaml
@@ -46,6 +46,7 @@ spec:
       - name: doc-html-{{ .Release.Name }}
         configMap:
           name: nginx-root-html-{{ .Release.Name }}
+      {{- if .Values.docServer.settings }}
       {{- with .Values.docServer.settings.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
@@ -53,6 +54,7 @@ spec:
       {{- with .Values.docServer.settings.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
 ---
 apiVersion: v1


### PR DESCRIPTION
Sorry, my latest PR actually contains a bug: https://github.com/developmentseed/eoapi-k8s/pull/176

Now that the values for `affinity` aren't always present, `docServer.settings` can be null which leads `docServer.settings.affinity` to crash.

This PR adds an additional check for this.