### PR TITLE
Introduce a list to avoid hardcoding of api service names.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ ingest:
 	@command -v bash >/dev/null 2>&1 || { echo "bash is required but not installed"; exit 1; }
 	@./ingest.sh || { echo "Ingestion failed."; exit 1; }
 
+tests:
+	@echo "Running tests."
+	@command -v helm >/dev/null 2>&1 || { echo "helm is required but not installed"; exit 1; }
+	@helm unittest helm-chart/eoapi -f 'tests/*.yaml' -v helm-chart/eoapi/test-helm-values.yaml
+
 help:
 	@echo "Makefile commands:"
 	@echo "  make deploy         -  Install eoAPI on a cluster kubectl is connected to."

--- a/helm-chart/eoapi/templates/_helpers.tpl
+++ b/helm-chart/eoapi/templates/_helpers.tpl
@@ -159,11 +159,23 @@ so we use this helper function to check autoscaling rules
 {{- define "eoapi.validateAutoscaleRules" -}}
 {{- if and .Values.ingress.enabled (ne .Values.ingress.className "nginx") }}
 {{/* "requestRate" cannot be enabled for any service if not "nginx" so give feedback and fail */}}
-{{- if (or (and .Values.raster.autoscaling.enabled (eq .Values.raster.autoscaling.type "requestRate")) (and .Values.stac.autoscaling.enabled (eq .Values.stac.autoscaling.type "requestRate")) (and .Values.vector.autoscaling.enabled (eq .Values.vector.autoscaling.type "requestRate")) ) }}
+{{- $requestRateEnabled := false }}
+{{- range .Values.apiServices }}
+{{- if and (index $.Values . "autoscaling" "enabled") (eq (index $.Values . "autoscaling" "type") "requestRate") }}
+{{- $requestRateEnabled = true }}
+{{- end }}
+{{- end }}
+{{- if $requestRateEnabled }}
 {{- fail "When using an 'ingress.className' other than 'nginx' you cannot enable autoscaling by 'requestRate' at this time b/c it's solely an nginx metric" }}
 {{- end }}
 {{/* "both" cannot be enabled for any service if not "nginx" so give feedback and fail */}}
-{{- if (or (and .Values.raster.autoscaling.enabled (eq .Values.raster.autoscaling.type "both")) (and .Values.stac.autoscaling.enabled (eq .Values.stac.autoscaling.type "both")) (and .Values.vector.autoscaling.enabled (eq .Values.vector.autoscaling.type "both")) ) }}
+{{- $bothEnabled := false }}
+{{- range .Values.apiServices }}
+{{- if and (index $.Values . "autoscaling" "enabled") (eq (index $.Values . "autoscaling" "type") "both") }}
+{{- $bothEnabled = true }}
+{{- end }}
+{{- end }}
+{{- if $bothEnabled }}
 {{- fail "When using an 'ingress.className' other than 'nginx' you cannot enable autoscaling by 'both' at this time b/c 'requestRate' is solely an nginx metric" }}
 {{- end }}
 {{- end }}

--- a/helm-chart/eoapi/templates/services/configmap.yaml
+++ b/helm-chart/eoapi/templates/services/configmap.yaml
@@ -1,5 +1,5 @@
 {{- range $serviceName, $v := .Values -}}
-{{- if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) }}
+{{- if has $serviceName $.Values.apiServices }}
 {{- if index $v "enabled" }}
 apiVersion: v1
 kind: ConfigMap
@@ -12,7 +12,7 @@ data:
 ---
 {{/* END: if index $v "enabled" */}}
 {{- end }}
-{{/* END: if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) */}}
+{{/* END: if has $serviceName $.Values.apiServices */}}
 {{- end }}
 {{/* END: range $serviceName, $v := .Values*/}}
 {{- end }}

--- a/helm-chart/eoapi/templates/services/deployment.yaml
+++ b/helm-chart/eoapi/templates/services/deployment.yaml
@@ -1,6 +1,6 @@
 {{ include "eoapi.validateTempDB" . }}
 {{- range $serviceName, $v := .Values -}}
-{{- if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) }}
+{{- if has $serviceName $.Values.apiServices }}
 {{- if index $v "enabled" }}
 apiVersion: apps/v1
 kind: Deployment
@@ -82,7 +82,7 @@ spec:
 ---
 {{/* END: if index $v "enabled" */}}
 {{- end }}
-{{/* END: if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) */}}
+{{/* END: if has $serviceName $.Values.apiServices */}}
 {{- end }}
 {{/* END: range $serviceName, $v := .Values*/}}
 {{- end }}

--- a/helm-chart/eoapi/templates/services/hpa.yaml
+++ b/helm-chart/eoapi/templates/services/hpa.yaml
@@ -1,6 +1,6 @@
 {{- include "eoapi.validateAutoscaleRules" . -}}
 {{- range $serviceName, $v := .Values -}}
-{{- if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) }}
+{{- if has $serviceName $.Values.apiServices }}
 {{- if index $v "autoscaling" "enabled" }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -44,7 +44,7 @@ spec:
 ---
 {{/* END: if index $v "autoscaling" "enabled" */}}
 {{- end }}
-{{/* END: if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) */}}
+{{/* END: if has $serviceName $.Values.apiServices */}}
 {{- end }}
 {{/* END: range $serviceName, $v := .Values*/}}
 {{- end }}

--- a/helm-chart/eoapi/templates/services/ingress-nginx.yaml
+++ b/helm-chart/eoapi/templates/services/ingress-nginx.yaml
@@ -31,7 +31,7 @@ spec:
     - http:
         paths:
           {{- range $serviceName, $v := .Values }}
-          {{- if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) }}
+          {{- if has $serviceName $.Values.apiServices }}
           {{- if (and (index $v "enabled") (not $.Values.testing)) }}
           - pathType: Prefix
             path: "/{{ $serviceName }}(/|$)(.*)"
@@ -49,7 +49,7 @@ spec:
                 port:
                   number: {{ $.Values.service.port }}
           {{- end }}{{/* END: if index $v "enabled" */}}
-          {{- end }}{{/* END: if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) */}}
+          {{- end }}{{/* END: if has $serviceName $.Values.apiServices */}}
           {{- end }}{{/* END: range $serviceName, $v := .Values*/}}
           {{- if (and (not $.Values.testing) (.Values.docServer.enabled)) }}
           - pathType: Prefix

--- a/helm-chart/eoapi/templates/services/ingress-traefik.yaml
+++ b/helm-chart/eoapi/templates/services/ingress-traefik.yaml
@@ -41,7 +41,7 @@ spec:
     - http:
         paths:
           {{- range $serviceName, $v := .Values }}
-          {{- if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) }}
+          {{- if has $serviceName $.Values.apiServices }}
           {{- if (and (index $v "enabled") (not $.Values.testing)) }}
           - pathType: Prefix
             path: "/{{ $serviceName }}"
@@ -59,7 +59,7 @@ spec:
                 port:
                   number: {{ $.Values.service.port }}
           {{- end }}{{/* END: if index $v "enabled" */}}
-          {{- end }}{{/* END: if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) */}}
+          {{- end }}{{/* END: if has $serviceName $.Values.apiServices */}}
           {{- end }}{{/* END: range $serviceName, $v := .Values*/}}
           {{- if (and (not $.Values.testing) (.Values.docServer.enabled)) }}
           - pathType: Prefix

--- a/helm-chart/eoapi/templates/services/service.yaml
+++ b/helm-chart/eoapi/templates/services/service.yaml
@@ -1,5 +1,5 @@
 {{- range $serviceName, $v := .Values -}}
-{{- if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) }}
+{{- if has $serviceName $.Values.apiServices }}
 {{- if index $v "enabled" }}
 apiVersion: v1
 kind: Service
@@ -28,7 +28,7 @@ spec:
 ---
 {{/* END: if index $v "enabled" */}}
 {{- end }}
-{{/* END: if (or (eq $serviceName "raster") (eq $serviceName "stac") (eq $serviceName "vector")) */}}
+{{/* END: if has $serviceName $.Values.externalServices */}}
 {{- end }}
 {{/* END: range $serviceName, $v := .Values*/}}
 {{- end }}

--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -170,6 +170,11 @@ pgstacBootstrap:
 ######################
 # API SERVICES
 ######################
+apiServices:
+  - raster
+  - stac
+  - vector
+
 raster:
   enabled: true
   autoscaling:


### PR DESCRIPTION
This is a preliminary step to https://github.com/developmentseed/eoapi-k8s/pull/161, which introduces a breaking change for the configuration file. This PR eliminates already the hard coded api services names, but introduced a list in `values.yaml` to indicate those, and therefore is backwards compatible.

I suggest we do a two step approach and bring first this one in, and then coordinate properly for the second step.