### PR TITLE
Update GCP Setup instructions

### DIFF
--- a/docs/gcp-gke.md
+++ b/docs/gcp-gke.md
@@ -85,6 +85,8 @@ gke-eoapi-test-default-pool-94a2b7e7-vg4f   Ready    <none>   5m   v1.31.5-gke.1
 
 NGINX Ingress Controller can be installed through `helm` using the following command:
 ```
+kubectl create ns eoapi
+
 helm upgrade --install ingress-nginx ingress-nginx \
   --repo https://kubernetes.github.io/ingress-nginx \
   --namespace eoapi

--- a/docs/gcp-gke.md
+++ b/docs/gcp-gke.md
@@ -44,7 +44,7 @@ Here's an example command to create a cluster. See the [gcloud docs](https://clo
 
 You might need to iterate on the command above, so to delete the cluster:
   ```
-  gcloud container clusters delete my-cluster --zone=us-central1-a
+  gcloud container clusters delete sandbox --zone=us-central1-a
   ```
 
 # Enable CSI Driver
@@ -53,6 +53,32 @@ CSI Driver is required for persistent volumes to be mounted to pods. You can ena
 
 ```
 gcloud container clusters update sandbox --update-addons=GcePersistentDiskCsiDriver=ENABLED --zone=us-central1-a
+```
+
+# Connect to Your Cluster
+
+See [GKE docs for installing and authenticating with kubectl](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin)
+
+See [docs for installing Helm](https://helm.sh/docs/intro/install/)
+
+Configure kubectl to connect to your GKE cluster:
+
+```
+gcloud container clusters get-credentials sandbox \
+    --region=us-central1-a
+```
+
+To test the connection, run:
+
+```
+kubectl get nodes
+```
+
+You should see something like:
+
+```
+NAME                                        STATUS   ROLES    AGE   VERSION
+gke-eoapi-test-default-pool-94a2b7e7-vg4f   Ready    <none>   5m   v1.31.5-gke.1233000
 ```
 
 # Install NGINX Ingress Controller
@@ -68,8 +94,12 @@ See the [NGINX Ingress Controller docs](https://kubernetes.github.io/ingress-ngi
 
 # Install Cert Manager
 
-Cert Manager can be installed through `helm` using the following command:
+Cert Manager can be installed through `helm` using the following commands:
 ```
+helm repo add jetstack https://charts.jetstack.io
+
+helm repo update
+
 helm upgrade --install cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Update GCP setup instructions to include some missing steps:
  - Install kubectl and authenticate
  - Install helm
  - Add jetstack helm repo, for cert-manager (found instructions [here](https://github.com/cert-manager/cert-manager/issues/1931#issuecomment-516020668))

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- I ran through the instructions got stuck, figured things out, and documented what I learned

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Run through the instructions on a clean cluster

----

Thank you for all the work you've done with this repo, it's a huge lift for our engineering team 🚀 🌎
