### PR TITLE
Let all eoAPI services wait for db bootstrap.

### DIFF
--- a/helm-chart/eoapi/templates/services/deployment.yaml
+++ b/helm-chart/eoapi/templates/services/deployment.yaml
@@ -30,7 +30,6 @@ spec:
         app: {{ $serviceName }}-{{ $.Release.Name }}
     spec:
       serviceAccountName: eoapi-sa-{{ $.Release.Name }}
-      {{- if eq $serviceName "stac" }}
       initContainers:
       - name: wait-for-pgstacbootstrap
         image: bitnami/kubectl:latest
@@ -44,7 +43,6 @@ spec:
             sleep 10
           done
           echo "pgstacbootstrap job completed successfully"
-      {{- end }}
       containers:
       - image: {{ index $v "image" "name" }}:{{ index $v "image" "tag" }}
         name: {{ $serviceName }}


### PR DESCRIPTION
Not only stac service needs to wait for the database to be ready. So let's wait with vector, raster and multidim services as well.