### PR TITLE
Reduce errors about too many db connections.

### DIFF
--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -346,6 +346,7 @@ stac:
       PORT: "8080"
       # https://www.uvicorn.org/settings/#production
       WEB_CONCURRENCY: "5"
+      DB_MIN_CONN_SIZE: "1"
 
 vector:
   enabled: true


### PR DESCRIPTION
On the stac service we got quite a few errors:

```
asyncpg.exceptions.TooManyConnectionsError: remaining connection slots are reserved for roles with the SUPERUSER attribute
```

They haven't been a blocker, but kept coming up and hindered debugging on other stuff. Let's get rid of them.