### PR TITLE
Remove hard-coded cert-manager configuration and improve TLS docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.1] - Unreleased
+
+### Breaking Changes
+- Remove hard-coded cert-manager configuration from ingress template [#227](https://github.com/developmentseed/eoapi-k8s/pull/227)
+
+### Changed
+- Simplify TLS configuration to allow user-controlled certificate management [#227](https://github.com/developmentseed/eoapi-k8s/pull/227)
+- Update documentation with comprehensive cert-manager setup guide [#227](https://github.com/developmentseed/eoapi-k8s/pull/227)
+
 ## [v0.7.0] - 2025-04-30
 
 ### Breaking Changes

--- a/helm-chart/eoapi/.helmignore
+++ b/helm-chart/eoapi/.helmignore
@@ -24,4 +24,4 @@
 tests/
 
 # Documentation files in templates
-templates/**/*.md
+templates/*/*.md

--- a/helm-chart/eoapi/.helmignore
+++ b/helm-chart/eoapi/.helmignore
@@ -22,3 +22,6 @@
 *.tmproj
 .vscode/
 tests/
+
+# Documentation files in templates
+templates/**/*.md

--- a/helm-chart/eoapi/templates/services/ingress.yaml
+++ b/helm-chart/eoapi/templates/services/ingress.yaml
@@ -20,9 +20,6 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: web
     traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-strip-prefix-middleware-{{ $.Release.Name }}@kubernetescrd
     {{- end }}
-    {{- if and .Values.ingress.tls.enabled .Values.ingress.tls.certManager .Values.ingress.tls.certManagerIssuer }}
-    cert-manager.io/issuer: {{ .Values.ingress.tls.certManagerIssuer }}
-    {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}

--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -55,9 +55,6 @@ ingress:
   tls:
     enabled: false
     secretName: eoapi-tls
-    certManager: false
-    certManagerIssuer: letsencrypt-prod
-    certManagerEmail: ""
 
 ######################
 # DATABASE


### PR DESCRIPTION
Fixes #226

This PR removes the hard-coded cert-manager configuration from the Helm chart and updates the documentation with a comprehensive guide for setting up TLS with cert-manager.

Changes:
1. Remove cert-manager annotations from ingress.yaml
2. Simplify TLS configuration in values.yaml to only include essential fields
3. Update unified-ingress.md documentation with:
   - Remove outdated cert-manager configuration
   - Add complete guide for setting up cert-manager with Let's Encrypt
   - Include examples for both staging and production environments
   - Show how to use ClusterIssuer for certificate management

Users can now fully control certificate management through their own annotations, with clear documentation on how to set it up using existing cluster resources.