### PR TITLE
Make 0.7.0 db upgrade run in ArgoCD.

### DIFF
--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -91,6 +91,45 @@ jobs:
 
           exit $?
 
+      - name: debug pgstac-eoapiuser-permissions-upgrade job failure
+        if: steps.helm-render-install-eoapi-templates.outcome == 'failure'
+        continue-on-error: true
+        run: |
+          echo "Extracting pgstac-eoapiuser-permissions-upgrade job info and logs for debugging..."
+          
+          # Get job details
+          echo "===== pgstac-eoapiuser-permissions-upgrade Job Details ====="
+          kubectl get job pgstac-eoapiuser-permissions-upgrade -o yaml || echo "Could not get job details"
+          
+          # Get pod details
+          echo "===== Pod Details ====="
+          kubectl get pods --selector=app=pgstac-eoapiuser-permissions-upgrade -o wide || echo "Could not find pods"
+          
+          # Extract logs from pods
+          echo "===== Pod Logs ====="
+          PODS=$(kubectl get pods --selector=app=pgstac-eoapiuser-permissions-upgrade -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
+          if [ -n "$PODS" ]; then
+            for POD in $PODS; do
+              echo "--- Logs from pod $POD ---"
+              kubectl logs $POD --previous || true  # Get logs from previous container if it exists
+              kubectl logs $POD || echo "Could not get logs from pod $POD"
+            done
+          else
+            echo "No pods found for pgstac-eoapiuser-permissions-upgrade job"
+          fi
+          
+          # Get pod descriptions for more details
+          echo "===== Pod Descriptions ====="
+          kubectl describe pods --selector=app=pgstac-eoapiuser-permissions-upgrade || echo "Could not describe pods"
+          
+          # Check the configmap contents
+          echo "===== initdb ConfigMap Contents ====="
+          kubectl get configmap initdb -o yaml || echo "Could not get initdb configmap"
+          
+          # Check for any related events
+          echo "===== Related Kubernetes Events ====="
+          kubectl get events | grep -E "pgstac-eoapiuser-permissions-upgrade|initdb" || echo "No relevant events found"
+
       - name: debug pgstac-migrate job failure
         if: steps.helm-render-install-eoapi-templates.outcome == 'failure'
         continue-on-error: true

--- a/helm-chart/eoapi/templates/pgstacbootstrap/eoapiuser-permissions-upgrade.yaml
+++ b/helm-chart/eoapi/templates/pgstacbootstrap/eoapiuser-permissions-upgrade.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.postgrescluster.enabled .Values.pgstacBootstrap.enabled .Release.IsUpgrade (semverCompare "< 0.7.0" .Values.previousVersion) }}
+{{- if and .Values.postgrescluster.enabled .Values.pgstacBootstrap.enabled (semverCompare "< 0.7.0" .Values.previousVersion) }}
 ---
 # This job is part of the upgrade process from pre-0.7.0 versions.
 # Prior to 0.7.0, database schema updates were run with superuser privileges.
@@ -30,11 +30,11 @@ spec:
             - |
               # Exit immediately if a command exits with a non-zero status
               set -e
-              
+
               # Run permission setup with superuser
               echo "Applying superuser permissions for upgrade from version {{ .Values.previousVersion }}..."
               PGUSER=postgres psql -f /opt/sql/initdb.sql
-              
+
               echo "Permissions upgrade complete"
           resources:
             {{- toYaml .Values.pgstacBootstrap.settings.resources | nindent 12 }}

--- a/helm-chart/eoapi/templates/pgstacbootstrap/eoapiuser-permissions-upgrade.yaml
+++ b/helm-chart/eoapi/templates/pgstacbootstrap/eoapiuser-permissions-upgrade.yaml
@@ -1,8 +1,10 @@
-{{- if and .Values.postgrescluster.enabled .Values.pgstacBootstrap.enabled (semverCompare "< 0.7.0" .Values.previousVersion) }}
+{{- if and .Values.postgrescluster.enabled .Values.pgstacBootstrap.enabled }}
 ---
 # This job is part of the upgrade process from pre-0.7.0 versions.
 # Prior to 0.7.0, database schema updates were run with superuser privileges.
 # This job ensures proper permissions are granted to the eoapi user during upgrade.
+# TODO: Remove with the next mayor verson and add to documentation that one needs to
+# through 0.7.x when upgrading.
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
Related to https://github.com/EOEPCA/data-access/issues/160

ArgoCD doesn't run with the flag `isUpgrade`, let's remove it. Anyway the db script it idempotent.