### PR TITLE
Added overrideRootPath option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.5] - 2025-07-11
+
+### Changed
+
+- Added option to overrid root-paths of API services [#245](https://github.com/developmentseed/eoapi-k8s/pull/245)
+
 ## [0.7.4] - 2025-06-30
 
 ### Changed

--- a/helm-chart/eoapi/Chart.yaml
+++ b/helm-chart/eoapi/Chart.yaml
@@ -39,7 +39,7 @@ annotations:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.7.4"
+version: "0.7.5"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-chart/eoapi/templates/services/multidim/deployment.yaml
+++ b/helm-chart/eoapi/templates/services/multidim/deployment.yaml
@@ -40,7 +40,11 @@ spec:
           {{- if (and (.Values.ingress.className) (or (eq .Values.ingress.className "nginx") (eq .Values.ingress.className "traefik"))) }}
           - "--proxy-headers"
           - "--forwarded-allow-ips=*"
+          {{- if .Values.multidim.overrideRootPath}}
+          - "--root-path={{ .Values.multidim.overrideRootPath }}"
+          {{- else }}
           - "--root-path={{ .Values.multidim.ingress.path }}"
+          {{- end }}
           {{- end }}{{/* needed for proxies and path rewrites on NLB */}}
         livenessProbe:
           tcpSocket:
@@ -51,14 +55,22 @@ spec:
           timeoutSeconds: 1
         readinessProbe:
           httpGet:
+            {{- if .Values.multidim.overrideRootPath}}
+            path: {{ .Values.multidim.overrideRootPath }}/healthz
+            {{- else}}
             path: /healthz
+            {{- end}}
             port: {{ .Values.service.port }}
           failureThreshold: 3
           periodSeconds: 15
           successThreshold: 1
         startupProbe:
           httpGet:
+            {{- if .Values.multidim.overrideRootPath}}
+            path: {{ .Values.multidim.overrideRootPath }}/healthz
+            {{- else}}
             path: /healthz
+            {{- end}}
             port: {{ .Values.service.port }}
           # check every sec for 1 minute
           periodSeconds: 1

--- a/helm-chart/eoapi/templates/services/raster/deployment.yaml
+++ b/helm-chart/eoapi/templates/services/raster/deployment.yaml
@@ -40,7 +40,11 @@ spec:
           {{- if (and (.Values.ingress.className) (or (eq .Values.ingress.className "nginx") (eq .Values.ingress.className "traefik"))) }}
           - "--proxy-headers"
           - "--forwarded-allow-ips=*"
+          {{- if .Values.raster.overrideRootPath}}
+          - "--root-path={{ .Values.raster.overrideRootPath }}"
+          {{- else }}
           - "--root-path={{ .Values.raster.ingress.path }}"
+          {{- end }}
           {{- end }}{{/* needed for proxies and path rewrites on NLB */}}
         livenessProbe:
           tcpSocket:
@@ -51,14 +55,22 @@ spec:
           timeoutSeconds: 1
         readinessProbe:
           httpGet:
+            {{- if .Values.raster.overrideRootPath}}
+            path: {{ .Values.raster.overrideRootPath }}/healthz
+            {{- else}}
             path: /healthz
+            {{- end}}
             port: {{ .Values.service.port }}
           failureThreshold: 3
           periodSeconds: 15
           successThreshold: 1
         startupProbe:
           httpGet:
+            {{- if .Values.raster.overrideRootPath}}
+            path: {{ .Values.raster.overrideRootPath }}/healthz
+            {{- else}}
             path: /healthz
+            {{- end}}
             port: {{ .Values.service.port }}
           # check every sec for 1 minute
           periodSeconds: 1

--- a/helm-chart/eoapi/templates/services/stac/deployment.yaml
+++ b/helm-chart/eoapi/templates/services/stac/deployment.yaml
@@ -40,7 +40,11 @@ spec:
           {{- if (and (.Values.ingress.className) (or (eq .Values.ingress.className "nginx") (eq .Values.ingress.className "traefik"))) }}
           - "--proxy-headers"
           - "--forwarded-allow-ips=*"
+          {{- if .Values.stac.overrideRootPath}}
+          - "--root-path={{ .Values.stac.overrideRootPath }}"
+          {{- else }}
           - "--root-path={{ .Values.stac.ingress.path }}"
+          {{- end }}
           {{- end }}{{/* needed for proxies and path rewrites on NLB */}}
         livenessProbe:
           tcpSocket:
@@ -51,14 +55,22 @@ spec:
           timeoutSeconds: 1
         readinessProbe:
           httpGet:
+            {{- if .Values.stac.overrideRootPath}}
+            path: {{ .Values.stac.overrideRootPath }}/_mgmt/ping
+            {{- else}}
             path: /_mgmt/ping
+            {{- end}}
             port: {{ .Values.service.port }}
           failureThreshold: 3
           periodSeconds: 15
           successThreshold: 1
         startupProbe:
           httpGet:
+            {{- if .Values.stac.overrideRootPath}}
+            path: {{ .Values.stac.overrideRootPath }}/_mgmt/ping
+            {{- else}}
             path: /_mgmt/ping
+            {{- end}}
             port: {{ .Values.service.port }}
           # check every sec for 1 minute
           periodSeconds: 1

--- a/helm-chart/eoapi/templates/services/vector/deployment.yaml
+++ b/helm-chart/eoapi/templates/services/vector/deployment.yaml
@@ -40,7 +40,11 @@ spec:
           {{- if (and (.Values.ingress.className) (or (eq .Values.ingress.className "nginx") (eq .Values.ingress.className "traefik"))) }}
           - "--proxy-headers"
           - "--forwarded-allow-ips=*"
+          {{- if .Values.vector.overrideRootPath}}
+          - "--root-path={{ .Values.vector.overrideRootPath }}"
+          {{- else }}
           - "--root-path={{ .Values.vector.ingress.path }}"
+          {{- end }}
           {{- end }}{{/* needed for proxies and path rewrites on NLB */}}
         livenessProbe:
           tcpSocket:
@@ -51,14 +55,22 @@ spec:
           timeoutSeconds: 1
         readinessProbe:
           httpGet:
+            {{- if .Values.vector.overrideRootPath}}
+            path: {{ .Values.vector.overrideRootPath }}/healthz
+            {{- else}}
             path: /healthz
+            {{- end}}
             port: {{ .Values.service.port }}
           failureThreshold: 3
           periodSeconds: 15
           successThreshold: 1
         startupProbe:
           httpGet:
+            {{- if .Values.vector.overrideRootPath}}
+            path: {{ .Values.vector.overrideRootPath }}/healthz
+            {{- else}}
             path: /healthz
+            {{- end}}
             port: {{ .Values.service.port }}
           # check every sec for 1 minute
           periodSeconds: 1

--- a/helm-chart/eoapi/values.schema.json
+++ b/helm-chart/eoapi/values.schema.json
@@ -108,6 +108,7 @@
         }
       }
     },
+
     "postgresql": {
       "type": "object",
       "properties": {
@@ -411,6 +412,10 @@
             "type": "string"
           },
           "description": "Container command"
+        },
+        "overrideRootPath": {
+          "type": "string",
+          "description": "Override root path for this service"
         },
         "settings": {
           "type": "object",


### PR DESCRIPTION
Related to https://github.com/EOEPCA/data-access/issues/172

It introduces an optional attribute `overrideRootPath` which allows to set a different `path` for the ingress than the application is available for health checks and internal root path settings. This might be necessary when a different proxy configuration is being used.