### PR TITLE
feat: add some missing metadata and enable annotations on browser service

### DIFF
--- a/charts/eoapi/templates/services/browser/deployment.yaml
+++ b/charts/eoapi/templates/services/browser/deployment.yaml
@@ -3,6 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: browser-{{ .Release.Name }}
+  labels:
+    app: browser-{{ .Release.Name }}
+    gitsha: {{ .Values.gitSha }}
 spec:
   replicas: {{.Values.browser.replicaCount}}
   selector:

--- a/charts/eoapi/templates/services/browser/service.yaml
+++ b/charts/eoapi/templates/services/browser/service.yaml
@@ -3,6 +3,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: browser-{{ .Release.Name }}
+  labels:
+    app: browser-{{ .Release.Name }}
+  {{- if .Values.browser.annotations }}
+  annotations:
+    {{- with .Values.browser.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   selector:
     app: browser-{{ .Release.Name }}

--- a/charts/eoapi/tests/stac_browser_tests.yaml
+++ b/charts/eoapi/tests/stac_browser_tests.yaml
@@ -1,0 +1,53 @@
+suite: stac browser service tests
+templates:
+  - templates/services/browser/deployment.yaml
+  - templates/services/browser/service.yaml
+tests:
+  - it: "stac browser deployment"
+    set:
+      raster.enabled: false
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: true
+      gitSha: "ABC123"
+    template: templates/services/browser/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchRegex:
+          path: metadata.name
+          pattern: ^browser-RELEASE-NAME$
+      - matchRegex:
+          path: metadata.labels.app
+          pattern: ^browser-RELEASE-NAME$
+      - equal:
+          path: metadata.labels.gitsha
+          value: "ABC123"
+  - it: "stac browser service"
+    set:
+      raster.enabled: false
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: true
+      browser.annotations:
+        annotation1: hello
+        annotation2: world
+      gitSha: "ABC123"
+    template: templates/services/browser/service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - matchRegex:
+          path: metadata.name
+          pattern: ^browser-RELEASE-NAME$
+      - matchRegex:
+          path: metadata.labels.app
+          pattern: ^browser-RELEASE-NAME$
+      - equal:
+          path: metadata.annotations.annotation1
+          value: hello
+      - equal:
+          path: metadata.annotations.annotation2
+          value: world


### PR DESCRIPTION
# What this PR is

To enable the stac browser to appear within the EOXHub workspace we're deploying in eopf-sentinel-zarr-explorer I need to be able to set annotations on the browser service

I also noticed the browser didn't have quite the same metadata as other services
