### PR TITLE
Fix hook execution order.

### DIFF
--- a/charts/eoapi/templates/pgstacbootstrap/configmap.yaml
+++ b/charts/eoapi/templates/pgstacbootstrap/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
   name: pgstac-settings-config-{{ $.Release.Name }}
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
-    helm.sh/hook-weight: "-6"
+    helm.sh/hook-weight: "-7"
     helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
 data:
   pgstac-settings.sql: |
@@ -22,7 +22,7 @@ metadata:
   name: initdb-sql-config-{{ $.Release.Name }}
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
-    helm.sh/hook-weight: "-6"
+    helm.sh/hook-weight: "-7"
     helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
 data:
   initdb.sql: |
@@ -36,7 +36,7 @@ metadata:
   name: initdb-json-config-{{ $.Release.Name }}
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
-    helm.sh/hook-weight: "-6"
+    helm.sh/hook-weight: "-7"
     helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
 data:
   {{- range $path, $bytes := $.Files.Glob "initdb-data/samples/*.json"  -}}

--- a/charts/eoapi/templates/pgstacbootstrap/eoap-superuser-initdb.yaml
+++ b/charts/eoapi/templates/pgstacbootstrap/eoap-superuser-initdb.yaml
@@ -11,7 +11,7 @@ metadata:
     app: pgstac-eoapi-superuser-init-db
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
-    helm.sh/hook-weight: "-7"
+    helm.sh/hook-weight: "-6"
     helm.sh/hook-delete-policy: "before-hook-creation"
 spec:
   template:
@@ -30,6 +30,10 @@ spec:
             - |
               # Exit immediately if a command exits with a non-zero status
               set -e
+
+              # Wait for the database to be ready
+              echo "Waiting for database to be ready..."
+              pypgstac pgready
 
               # Run the initial setup with superuser
               PGUSER=postgres psql -f /opt/sql/initdb.sql
@@ -77,5 +81,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  backoffLimit: 1
+  backoffLimit: 5
 {{- end }}


### PR DESCRIPTION
This should help us get rid of the `job pgstac-eoapi-superuser-init-db failed: BackoffLimitExceeded` error.