### PR TITLE
Name components consistently.

### DIFF
--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -228,28 +228,28 @@ jobs:
           echo ""
 
           echo "Waiting for raster service to be ready..."
-          kubectl wait --for=condition=Ready pod -l app=raster-${RELEASE_NAME} --timeout=180s || {
+          kubectl wait --for=condition=Ready pod -l app=${RELEASE_NAME}-raster --timeout=180s || {
             echo "Raster service failed to become ready. Checking status..."
-            kubectl get pods -l app=raster-${RELEASE_NAME} -o wide
-            kubectl describe pods -l app=raster-${RELEASE_NAME}
+            kubectl get pods -l app=${RELEASE_NAME}-raster -o wide
+            kubectl describe pods -l app=${RELEASE_NAME}-raster
             exit 1
           }
           echo "raster service is ready, moving on..."
 
           echo "Waiting for vector service to be ready..."
-          kubectl wait --for=condition=Ready pod -l app=vector-${RELEASE_NAME} --timeout=180s || {
+          kubectl wait --for=condition=Ready pod -l app=${RELEASE_NAME}-vector --timeout=180s || {
             echo "Vector service failed to become ready. Checking status..."
-            kubectl get pods -l app=vector-${RELEASE_NAME} -o wide
-            kubectl describe pods -l app=vector-${RELEASE_NAME}
+            kubectl get pods -l app=${RELEASE_NAME}-vector -o wide
+            kubectl describe pods -l app=${RELEASE_NAME}-vector
             exit 1
           }
           echo "vector service is ready, moving on..."
 
           echo "Waiting for stac service to be ready..."
-          kubectl wait --for=condition=Ready pod -l app=stac-${RELEASE_NAME} --timeout=180s || {
+          kubectl wait --for=condition=Ready pod -l app=${RELEASE_NAME}-stac --timeout=180s || {
             echo "STAC service failed to become ready. Checking status..."
-            kubectl get pods -l app=stac-${RELEASE_NAME} -o wide
-            kubectl describe pods -l app=stac-${RELEASE_NAME}
+            kubectl get pods -l app=${RELEASE_NAME}-stac -o wide
+            kubectl describe pods -l app=${RELEASE_NAME}-stac
             exit 1
           }
           echo "all services are ready, moving on..."
@@ -271,9 +271,9 @@ jobs:
           # Check init container logs for all services
           for SERVICE in raster vector stac multidim; do
             echo "===== $SERVICE Service Pod Status ====="
-            kubectl get pods -l app=$SERVICE-$RELEASE_NAME -o wide || echo "No $SERVICE pods found"
+            kubectl get pods -l app=$RELEASE_NAME-$SERVICE -o wide || echo "No $SERVICE pods found"
             
-            POD_NAME=$(kubectl get pod -l app=$SERVICE-$RELEASE_NAME -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+            POD_NAME=$(kubectl get pod -l app=$RELEASE_NAME-$SERVICE -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
             if [ -n "$POD_NAME" ]; then
               echo "===== $SERVICE Pod ($POD_NAME) Init Container Logs ====="
               kubectl logs pod/$POD_NAME -c wait-for-pgstac-jobs --tail=100 || echo "Could not get $SERVICE init container logs"
@@ -296,15 +296,15 @@ jobs:
           
           # Check pgstac jobs using labels instead of hardcoded names
           for APP_LABEL in pgstac-migrate pgstac-load-samples; do
-            echo "===== Jobs with app=$APP_LABEL Status ====="
-            JOBS=$(kubectl get jobs -l app=$APP_LABEL -o name 2>/dev/null || true)
+            echo "===== Jobs with app=$RELEASE_NAME-$APP_LABEL Status ====="
+            JOBS=$(kubectl get jobs -l app=$RELEASE_NAME-$APP_LABEL -o name 2>/dev/null || true)
             if [ -n "$JOBS" ]; then
               for JOB in $JOBS; do
                 echo "--- Job $JOB ---"
                 kubectl get "$JOB" -o yaml 2>/dev/null | grep -A 10 -E "conditions|status:" || echo "Could not get status for $JOB"
               done
             else
-              echo "No jobs found with app=$APP_LABEL label"
+              echo "No jobs found with app=$RELEASE_NAME-$APP_LABEL label"
             fi
             echo ""
           done

--- a/charts/eoapi-support/templates/dashboard.config.yaml
+++ b/charts/eoapi-support/templates/dashboard.config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: eoapi-dashboards
+  name: {{ .Release.Name }}-dashboards
   labels:
     eoapi_dashboard: "1"
 data:

--- a/charts/eoapi-support/values.yaml
+++ b/charts/eoapi-support/values.yaml
@@ -2,9 +2,10 @@
 # so giving props where props are due to Yuvi Panda :sparkles:
 prometheus-adapter:
   prometheus:
-    # NOTE: the `url` below make some assumptions about the namespace where you released eoapi and prometheus
-    # 1) that you didn't change the default name of the `prometheus-server` or the port and installed in eoapi namespace
-    # 2) namely that you ran `helm install eoapi --create-namespace=eoapi`  with the `eoapi` namespace
+    # NOTE: the `url` below makes assumptions about release name and namespace:
+    # 1) Release name is "eoapi-support" (follows RELEASE_NAME-prometheus-server pattern)
+    # 2) Deployed in "eoapi" namespace
+    # 3) If using different release name, update to: http://YOUR_RELEASE_NAME-prometheus-server.YOUR_NAMESPACE.svc.cluster.local
     url: http://eoapi-support-prometheus-server.eoapi.svc.cluster.local
     port: 80
     path: ""
@@ -136,9 +137,10 @@ grafana:
       - name: prometheus
         orgId: 1
         type: prometheus
-        # NOTE: the `url` below make some assumptions about the namespace where you released eoapi and prometheus
-        # 1) that you didn't change the default name of the `prometheus-server` or the port and installed in eoapi namespace
-        # 2) namely that you ran `helm install eoapi --create-namespace=eoapi`  with the `eoapi` namespace
+        # NOTE: the `url` below makes assumptions about release name and namespace:
+        # 1) Release name is "eoapi-support" (follows RELEASE_NAME-prometheus-server pattern)
+        # 2) Deployed in "eoapi" namespace
+        # 3) If using different release name, update to: http://YOUR_RELEASE_NAME-prometheus-server.YOUR_NAMESPACE.svc.cluster.local
         url: http://eoapi-support-prometheus-server.eoapi.svc.cluster.local
         access: proxy
         jsonData:
@@ -161,7 +163,11 @@ grafana:
           path: /var/lib/grafana/dashboards/default
 
   dashboardsConfigMaps:
-    default: "eoapi-dashboards"
+    # NOTE: This must match the ConfigMap name created in templates/dashboard.config.yaml
+    # The template creates: {{ .Release.Name }}-dashboards
+    # If release name is "eoapi-support", this should be "eoapi-support-dashboards"
+    # Update this value to match your actual release name + "-dashboards"
+    default: "eoapi-support-dashboards"
 
 metrics-server:
   apiService:

--- a/charts/eoapi/templates/pgstacbootstrap/configmap.yaml
+++ b/charts/eoapi/templates/pgstacbootstrap/configmap.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: pgstac-settings-config-{{ $.Release.Name }}
+  name: {{ $.Release.Name }}-pgstac-settings-config
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
     helm.sh/hook-weight: "-7"
@@ -19,7 +19,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: initdb-sql-config-{{ $.Release.Name }}
+  name: {{ $.Release.Name }}-initdb-sql-config
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
     helm.sh/hook-weight: "-7"
@@ -33,7 +33,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: initdb-json-config-{{ $.Release.Name }}
+  name: {{ $.Release.Name }}-initdb-json-config
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
     helm.sh/hook-weight: "-7"
@@ -49,7 +49,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: initdb
+  name: {{ .Release.Name }}-initdb
 data:
   initdb.sql: |
     \c {{ .Values.pgstacBootstrap.settings.database }}

--- a/charts/eoapi/templates/pgstacbootstrap/eoap-superuser-initdb.yaml
+++ b/charts/eoapi/templates/pgstacbootstrap/eoap-superuser-initdb.yaml
@@ -6,9 +6,9 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: pgstac-eoapi-superuser-init-db
+  name: {{ .Release.Name }}-pgstac-superuser-init-db
   labels:
-    app: pgstac-eoapi-superuser-init-db
+    app: {{ .Release.Name }}-pgstac-superuser-init-db
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
     helm.sh/hook-weight: "-6"
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       labels:
-        app: pgstac-eoapi-superuser-init-db
+        app: {{ .Release.Name }}-pgstac-superuser-init-db
     spec:
       restartPolicy: Never
       containers:
@@ -42,7 +42,7 @@ spec:
             {{- toYaml .Values.pgstacBootstrap.settings.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /opt/sql
-              name: initdb-config
+              name: {{ .Release.Name }}-initdb-config
           env:
             - name: PGUSER
               valueFrom:
@@ -70,9 +70,9 @@ spec:
                   name: {{ $.Values.postgrescluster.name | default $.Release.Name }}-pguser-postgres
                   key: dbname
       volumes:
-        - name: initdb-config
+        - name: {{ .Release.Name }}-initdb-config
           configMap:
-            name: initdb
+            name: {{ .Release.Name }}-initdb
       {{- with .Values.pgstacBootstrap.settings.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/eoapi/templates/pgstacbootstrap/job.yaml
+++ b/charts/eoapi/templates/pgstacbootstrap/job.yaml
@@ -25,7 +25,7 @@ kind: Job
 metadata:
   name: {{ .Release.Name }}-pgstac-migrate
   labels:
-    app: pgstac-migrate
+    app: {{ .Release.Name }}-pgstac-migrate
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
     helm.sh/hook-weight: "-5"
@@ -34,7 +34,7 @@ spec:
   template:
     metadata:
       labels:
-        app: pgstac-migrate
+        app: {{ .Release.Name }}-pgstac-migrate
     spec:
       restartPolicy: Never
       containers:
@@ -68,13 +68,13 @@ spec:
             {{- toYaml .Values.pgstacBootstrap.settings.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /opt/settings
-              name: pgstac-settings-volume-{{ .Release.Name }}
+              name: {{ .Release.Name }}-pgstac-settings-volume
           env:
             {{- include "eoapi.postgresqlEnv" . | nindent 12 }}
       volumes:
-        - name: pgstac-settings-volume-{{ .Release.Name }}
+        - name: {{ .Release.Name }}-pgstac-settings-volume
           configMap:
-            name: pgstac-settings-config-{{ .Release.Name }}
+            name: {{ .Release.Name }}-pgstac-settings-config
       {{- with .Values.pgstacBootstrap.settings.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
@@ -93,7 +93,7 @@ kind: Job
 metadata:
   name: {{ .Release.Name }}-pgstac-load-samples
   labels:
-    app: pgstac-load-samples
+    app: {{ .Release.Name }}-pgstac-load-samples
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
     helm.sh/hook-weight: "-4"
@@ -102,7 +102,7 @@ spec:
   template:
     metadata:
       labels:
-        app: pgstac-load-samples
+        app: {{ .Release.Name }}-pgstac-load-samples
     spec:
       restartPolicy: Never
       containers:
@@ -134,18 +134,18 @@ spec:
             {{- toYaml .Values.pgstacBootstrap.settings.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /opt/sql
-              name: initdb-sql-volume-{{ .Release.Name }}
+              name: {{ .Release.Name }}-initdb-sql-volume
             - mountPath: /opt/data
-              name: initdb-json-volume-{{ .Release.Name }}
+              name: {{ .Release.Name }}-initdb-json-volume
           env:
             {{- include "eoapi.postgresqlEnv" . | nindent 12 }}
       volumes:
-        - name: initdb-sql-volume-{{ .Release.Name }}
+        - name: {{ .Release.Name }}-initdb-sql-volume
           configMap:
-            name: initdb-sql-config-{{ .Release.Name }}
-        - name: initdb-json-volume-{{ .Release.Name }}
+            name: {{ .Release.Name }}-initdb-sql-config
+        - name: {{ .Release.Name }}-initdb-json-volume
           configMap:
-            name: initdb-json-config-{{ .Release.Name }}
+            name: {{ .Release.Name }}-initdb-json-config
       {{- with .Values.pgstacBootstrap.settings.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/charts/eoapi/templates/service-account.yaml
+++ b/charts/eoapi/templates/service-account.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "eoapi.serviceAccountName" . }}
   labels:
-    app: eoapi-{{ .Release.Name }}
+    app: eoapi-eoapi-{{ .Release.Name }}
     {{- range $key, $value := .Values.serviceAccount.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/charts/eoapi/templates/services/_common.tpl
+++ b/charts/eoapi/templates/services/_common.tpl
@@ -109,9 +109,9 @@ initContainers:
       done
     }
     
-    wait_for_job_by_label "app=pgstac-migrate" "pgstac-migrate"
+    wait_for_job_by_label "app={{ .Release.Name }}-pgstac-migrate" "pgstac-migrate"
     {{- if .Values.pgstacBootstrap.settings.loadSamples }}
-    wait_for_job_by_label "app=pgstac-load-samples" "pgstac-load-samples"
+    wait_for_job_by_label "app={{ .Release.Name }}-pgstac-load-samples" "pgstac-load-samples"
     {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/eoapi/templates/services/browser/deployment.yaml
+++ b/charts/eoapi/templates/services/browser/deployment.yaml
@@ -2,19 +2,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: browser-{{ .Release.Name }}
+  name: {{ .Release.Name }}-browser
   labels:
-    app: browser-{{ .Release.Name }}
+    app: {{ .Release.Name }}-browser
     gitsha: {{ .Values.gitSha }}
 spec:
   replicas: {{.Values.browser.replicaCount}}
   selector:
     matchLabels:
-      app: browser-{{ .Release.Name }}
+      app: {{ .Release.Name }}-browser
   template:
     metadata:
       labels:
-        app: browser-{{ .Release.Name }}
+        app: {{ .Release.Name }}-browser
     spec:
       containers:
         - name: browser

--- a/charts/eoapi/templates/services/browser/service.yaml
+++ b/charts/eoapi/templates/services/browser/service.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: browser-{{ .Release.Name }}
+  name: {{ .Release.Name }}-browser
   labels:
-    app: browser-{{ .Release.Name }}
+    app: {{ .Release.Name }}-browser
   {{- if .Values.browser.annotations }}
   annotations:
     {{- with .Values.browser.annotations }}
@@ -13,7 +13,7 @@ metadata:
   {{- end }}
 spec:
   selector:
-    app: browser-{{ .Release.Name }}
+    app: {{ .Release.Name }}-browser
   ports:
     - protocol: TCP
       port: 8080

--- a/charts/eoapi/templates/services/doc-server.yaml
+++ b/charts/eoapi/templates/services/doc-server.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: doc-server-html-{{ .Release.Name }}
+  name: {{ .Release.Name }}-doc-server-html
 data:
   index.html: |
     <html>
@@ -27,29 +27,29 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: doc-server-{{ .Release.Name }}
+  name: {{ .Release.Name }}-doc-server
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: doc-server-{{ .Release.Name }}
+      app: {{ .Release.Name }}-doc-server
   template:
     metadata:
       labels:
-        app: doc-server-{{ .Release.Name }}
+        app: {{ .Release.Name }}-doc-server
     spec:
       containers:
       - name: doc-server
         image: nginx:alpine
         volumeMounts:
-        - name: doc-html-{{ .Release.Name }}
+        - name: {{ .Release.Name }}-doc-html
           mountPath: /usr/share/nginx/html
         ports:
         - containerPort: 80
       volumes:
-      - name: doc-html-{{ .Release.Name }}
+      - name: {{ .Release.Name }}-doc-html
         configMap:
-          name: doc-server-html-{{ .Release.Name }}
+          name: {{ .Release.Name }}-doc-server-html
       {{- if .Values.docServer.settings }}
       {{- with .Values.docServer.settings.affinity }}
       affinity:
@@ -64,10 +64,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: doc-server-{{ .Release.Name }}
+  name: {{ .Release.Name }}-doc-server
 spec:
   selector:
-    app: doc-server-{{ .Release.Name }}
+    app: {{ .Release.Name }}-doc-server
   ports:
     - protocol: TCP
       port: 80

--- a/charts/eoapi/templates/services/ingress-browser.yaml
+++ b/charts/eoapi/templates/services/ingress-browser.yaml
@@ -9,9 +9,9 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: eoapi-ingress-browser-{{ .Release.Name }}
+  name: {{ .Release.Name }}-ingress-browser
   labels:
-    app: eoapi-{{ .Release.Name }}
+    app: {{ .Release.Name }}-ingress-browser
   annotations:
     {{- if .Values.ingress.annotations }}
 {{ toYaml .Values.ingress.annotations | indent 4 }}
@@ -23,7 +23,7 @@ metadata:
     # Temporary annotations for Traefik until uvicorn support real prefix in ASGI: https://github.com/encode/uvicorn/discussions/2490
     {{- if eq .Values.ingress.className "traefik" }}
     traefik.ingress.kubernetes.io/router.entrypoints: web
-    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-strip-prefix-middleware-{{ $.Release.Name }}@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-{{ $.Release.Name }}-strip-prefix-middleware@kubernetescrd
     {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
@@ -40,7 +40,7 @@ spec:
             path: "/browser{{ if eq $.Values.ingress.className "nginx" }}(/|$)(.*){{ end }}"
             backend:
               service:
-                name: browser-{{ $.Release.Name }}
+                name: {{ .Release.Name }}-browser
                 port:
                   number: 8080
           {{- end }}
@@ -56,7 +56,7 @@ spec:
             path: "/browser{{ if eq .Values.ingress.className "nginx" }}(/|$)(.*){{ end }}"
             backend:
               service:
-                name: browser-{{ $.Release.Name }}
+                name: {{ .Release.Name }}-browser
                 port:
                   number: 8080
           {{- end }}

--- a/charts/eoapi/templates/services/ingress.yaml
+++ b/charts/eoapi/templates/services/ingress.yaml
@@ -8,9 +8,9 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: eoapi-ingress-{{ .Release.Name }}
+  name: {{ .Release.Name }}-ingress
   labels:
-    app: eoapi-{{ .Release.Name }}
+    app: {{ .Release.Name }}-ingress
   annotations:
     {{- if eq .Values.ingress.className "nginx" }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
@@ -22,7 +22,7 @@ metadata:
     # Temporary annotations for Traefik until uvicorn support real prefix in ASGI: https://github.com/encode/uvicorn/discussions/2490
     {{- if eq .Values.ingress.className "traefik" }}
     traefik.ingress.kubernetes.io/router.entrypoints: web
-    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-strip-prefix-middleware-{{ $.Release.Name }}@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-{{ $.Release.Name }}-strip-prefix-middleware@kubernetescrd
     {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
@@ -39,7 +39,7 @@ spec:
             path: {{ $.Values.raster.ingress.path }}{{ if eq $.Values.ingress.className "nginx" }}(/|$)(.*){{ end }}
             backend:
               service:
-                name: raster-{{ $.Release.Name }}
+                name: {{ $.Release.Name }}-raster
                 port:
                   number: {{ $.Values.service.port }}
           {{- end }}
@@ -49,7 +49,7 @@ spec:
             path: {{ $.Values.stac.ingress.path }}{{ if eq $.Values.ingress.className "nginx" }}(/|$)(.*){{ end }}
             backend:
               service:
-                name: stac-{{ $.Release.Name }}
+                name: {{ $.Release.Name }}-stac
                 port:
                   number: {{ $.Values.service.port }}
           {{- end }}
@@ -59,7 +59,7 @@ spec:
             path: {{ $.Values.vector.ingress.path }}{{ if eq $.Values.ingress.className "nginx" }}(/|$)(.*){{ end }}
             backend:
               service:
-                name: vector-{{ $.Release.Name }}
+                name: {{ $.Release.Name }}-vector
                 port:
                   number: {{ $.Values.service.port }}
           {{- end }}
@@ -69,7 +69,7 @@ spec:
             path: {{ $.Values.multidim.ingress.path }}{{ if eq $.Values.ingress.className "nginx" }}(/|$)(.*){{ end }}
             backend:
               service:
-                name: multidim-{{ $.Release.Name }}
+                name: {{ $.Release.Name }}-multidim
                 port:
                   number: {{ $.Values.service.port }}
           {{- end }}
@@ -79,7 +79,7 @@ spec:
             path: "/{{ $.Values.ingress.rootPath | default "" }}"
             backend:
               service:
-                name: doc-server-{{ $.Release.Name }}
+                name: {{ $.Release.Name }}-doc-server
                 port:
                   number: 80
           {{- end }}
@@ -95,7 +95,7 @@ spec:
             path: {{ .Values.raster.ingress.path }}{{ if eq .Values.ingress.className "nginx" }}(/|$)(.*){{ end }}
             backend:
               service:
-                name: raster-{{ $.Release.Name }}
+                name: {{ .Release.Name }}-raster
                 port:
                   number: {{ .Values.service.port }}
           {{- end }}
@@ -105,7 +105,7 @@ spec:
             path: {{ .Values.stac.ingress.path }}{{ if eq .Values.ingress.className "nginx" }}(/|$)(.*){{ end }}
             backend:
               service:
-                name: stac-{{ $.Release.Name }}
+                name: {{ .Release.Name }}-stac
                 port:
                   number: {{ .Values.service.port }}
           {{- end }}
@@ -115,7 +115,7 @@ spec:
             path: {{ .Values.vector.ingress.path }}{{ if eq .Values.ingress.className "nginx" }}(/|$)(.*){{ end }}
             backend:
               service:
-                name: vector-{{ $.Release.Name }}
+                name: {{ .Release.Name }}-vector
                 port:
                   number: {{ .Values.service.port }}
           {{- end }}
@@ -125,7 +125,7 @@ spec:
             path: {{ .Values.multidim.ingress.path }}{{ if eq .Values.ingress.className "nginx" }}(/|$)(.*){{ end }}
             backend:
               service:
-                name: multidim-{{ $.Release.Name }}
+                name: {{ .Release.Name }}-multidim
                 port:
                   number: {{ .Values.service.port }}
           {{- end }}
@@ -135,7 +135,7 @@ spec:
             path: "/{{ $.Values.ingress.rootPath | default "" }}"
             backend:
               service:
-                name: doc-server-{{ $.Release.Name }}
+                name: {{ .Release.Name }}-doc-server
                 port:
                   number: 80
           {{- end }}

--- a/charts/eoapi/templates/services/multidim/configmap.yaml
+++ b/charts/eoapi/templates/services/multidim/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: multidim-envvar-configmap-{{ .Release.Name }}
+  name: {{ .Release.Name }}-multidim-envvar-configmap
 data:
   {{- range $envKey, $envValue := .Values.multidim.settings.envVars }}
   {{ upper $envKey }}: {{ $envValue | quote }}

--- a/charts/eoapi/templates/services/multidim/deployment.yaml
+++ b/charts/eoapi/templates/services/multidim/deployment.yaml
@@ -3,9 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: multidim-{{ .Release.Name }}
+    app: {{ .Release.Name }}-multidim
     gitsha: {{ .Values.gitSha }}
-  name: multidim-{{ .Release.Name }}
+  name: {{ .Release.Name }}-multidim
   {{- if .Values.multidim.annotations }}
   annotations:
     {{- with .Values.multidim.annotations }}
@@ -22,11 +22,11 @@ spec:
       maxUnavailable: 0
   selector:
     matchLabels:
-      app: multidim-{{ .Release.Name }}
+      app: {{ .Release.Name }}-multidim
   template:
     metadata:
       labels:
-        app: multidim-{{ .Release.Name }}
+        app: {{ .Release.Name }}-multidim
         {{- with .Values.multidim.settings.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -85,7 +85,7 @@ spec:
           {{- include "eoapi.commonEnvVars" (dict "service" "multidim" "root" .) | nindent 10 }}
         envFrom:
           - configMapRef:
-              name: multidim-envvar-configmap-{{ .Release.Name }}
+              name: {{ .Release.Name }}-multidim-envvar-configmap
           {{- if .Values.multidim.settings.extraEnvFrom }}
           {{- toYaml .Values.multidim.settings.extraEnvFrom | nindent 10 }}
           {{- end }}

--- a/charts/eoapi/templates/services/multidim/hpa.yaml
+++ b/charts/eoapi/templates/services/multidim/hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: multidim-hpa-{{ .Release.Name }}
+  name: {{ .Release.Name }}-multidim-hpa
   labels:
-    app: multidim-{{ .Release.Name }}
+    app: {{ .Release.Name }}-multidim
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: multidim-{{ .Release.Name }}
+    name: {{ .Release.Name }}-multidim
   minReplicas: {{ .Values.multidim.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.multidim.autoscaling.maxReplicas }}
   behavior:

--- a/charts/eoapi/templates/services/multidim/service.yaml
+++ b/charts/eoapi/templates/services/multidim/service.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: multidim-{{ $.Release.Name }}
+  name: {{ .Release.Name }}-multidim
   labels:
-    app: multidim-{{ .Release.Name }}
+    app: {{ .Release.Name }}-multidim
 spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.port }}
   selector:
-    app: multidim-{{ .Release.Name }}
+    app: {{ .Release.Name }}-multidim
 {{- end }}

--- a/charts/eoapi/templates/services/raster/configmap.yaml
+++ b/charts/eoapi/templates/services/raster/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: raster-envvar-configmap-{{ .Release.Name }}
+  name: {{ .Release.Name }}-raster-envvar-configmap
 data:
   {{- range $envKey, $envValue := .Values.raster.settings.envVars }}
   {{ upper $envKey }}: {{ $envValue | quote }}

--- a/charts/eoapi/templates/services/raster/deployment.yaml
+++ b/charts/eoapi/templates/services/raster/deployment.yaml
@@ -3,9 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: raster-{{ .Release.Name }}
+    app: {{ .Release.Name }}-raster
     gitsha: {{ .Values.gitSha }}
-  name: raster-{{ .Release.Name }}
+  name: {{ .Release.Name }}-raster
   {{- if .Values.raster.annotations }}
   annotations:
     {{- with .Values.raster.annotations }}
@@ -22,11 +22,11 @@ spec:
       maxUnavailable: 0
   selector:
     matchLabels:
-      app: raster-{{ .Release.Name }}
+      app: {{ .Release.Name }}-raster
   template:
     metadata:
       labels:
-        app: raster-{{ .Release.Name }}
+        app: {{ .Release.Name }}-raster
         {{- with .Values.raster.settings.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -85,7 +85,7 @@ spec:
           {{- include "eoapi.commonEnvVars" (dict "service" "raster" "root" .) | nindent 10 }}
         envFrom:
           - configMapRef:
-              name: raster-envvar-configmap-{{ .Release.Name }}
+              name: {{ .Release.Name }}-raster-envvar-configmap
           {{- if .Values.raster.settings.extraEnvFrom }}
           {{- toYaml .Values.raster.settings.extraEnvFrom | nindent 10 }}
           {{- end }}

--- a/charts/eoapi/templates/services/raster/hpa.yaml
+++ b/charts/eoapi/templates/services/raster/hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: raster-hpa-{{ .Release.Name }}
+  name: {{ .Release.Name }}-raster-hpa
   labels:
-    app: raster-{{ .Release.Name }}
+    app: {{ .Release.Name }}-raster
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: raster-{{ .Release.Name }}
+    name: {{ .Release.Name }}-raster
   minReplicas: {{ .Values.raster.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.raster.autoscaling.maxReplicas }}
   behavior:

--- a/charts/eoapi/templates/services/raster/service.yaml
+++ b/charts/eoapi/templates/services/raster/service.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: raster-{{ $.Release.Name }}
+  name: {{ .Release.Name }}-raster
   labels:
-    app: raster-{{ .Release.Name }}
+    app: {{ .Release.Name }}-raster
 spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.port }}
   selector:
-    app: raster-{{ .Release.Name }}
+    app: {{ .Release.Name }}-raster
 {{- end }}

--- a/charts/eoapi/templates/services/stac/configmap.yaml
+++ b/charts/eoapi/templates/services/stac/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: stac-envvar-configmap-{{ .Release.Name }}
+  name: {{ .Release.Name }}-stac-envvar-configmap
 data:
   {{- range $envKey, $envValue := .Values.stac.settings.envVars }}
   {{ upper $envKey }}: {{ $envValue | quote }}

--- a/charts/eoapi/templates/services/stac/deployment.yaml
+++ b/charts/eoapi/templates/services/stac/deployment.yaml
@@ -3,9 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: stac-{{ .Release.Name }}
+    app: {{ .Release.Name }}-stac
     gitsha: {{ .Values.gitSha }}
-  name: stac-{{ .Release.Name }}
+  name: {{ .Release.Name }}-stac
   {{- if .Values.stac.annotations }}
   annotations:
     {{- with .Values.stac.annotations }}
@@ -22,11 +22,11 @@ spec:
       maxUnavailable: 0
   selector:
     matchLabels:
-      app: stac-{{ .Release.Name }}
+      app: {{ .Release.Name }}-stac
   template:
     metadata:
       labels:
-        app: stac-{{ .Release.Name }}
+        app: {{ .Release.Name }}-stac
         {{- with .Values.stac.settings.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -85,7 +85,7 @@ spec:
           {{- include "eoapi.commonEnvVars" (dict "service" "stac" "root" .) | nindent 10 }}
         envFrom:
           - configMapRef:
-              name: stac-envvar-configmap-{{ .Release.Name }}
+              name: {{ .Release.Name }}-stac-envvar-configmap
           {{- if .Values.stac.settings.extraEnvFrom }}
           {{- toYaml .Values.stac.settings.extraEnvFrom | nindent 10 }}
           {{- end }}

--- a/charts/eoapi/templates/services/stac/hpa.yaml
+++ b/charts/eoapi/templates/services/stac/hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: stac-hpa-{{ .Release.Name }}
+  name: {{ .Release.Name }}-stac-hpa
   labels:
-    app: stac-{{ .Release.Name }}
+    app: {{ .Release.Name }}-stac
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: stac-{{ .Release.Name }}
+    name: {{ .Release.Name }}-stac
   minReplicas: {{ .Values.stac.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.stac.autoscaling.maxReplicas }}
   behavior:

--- a/charts/eoapi/templates/services/stac/service.yaml
+++ b/charts/eoapi/templates/services/stac/service.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: stac-{{ $.Release.Name }}
+  name: {{ .Release.Name }}-stac
   labels:
-    app: stac-{{ .Release.Name }}
+    app: {{ .Release.Name }}-stac
 spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.port }}
   selector:
-    app: stac-{{ .Release.Name }}
+    app: {{ .Release.Name }}-stac
 {{- end }}

--- a/charts/eoapi/templates/services/traefik-middleware.yaml
+++ b/charts/eoapi/templates/services/traefik-middleware.yaml
@@ -2,7 +2,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: strip-prefix-middleware-{{ .Release.Name }}
+  name: {{ .Release.Name }}-strip-prefix-middleware
   namespace: {{ .Release.Namespace }}
 spec:
   stripPrefix:

--- a/charts/eoapi/templates/services/vector/configmap.yaml
+++ b/charts/eoapi/templates/services/vector/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vector-envvar-configmap-{{ .Release.Name }}
+  name: {{ .Release.Name }}-vector-envvar-configmap
 data:
   {{- range $envKey, $envValue := .Values.vector.settings.envVars }}
   {{ upper $envKey }}: {{ $envValue | quote }}

--- a/charts/eoapi/templates/services/vector/deployment.yaml
+++ b/charts/eoapi/templates/services/vector/deployment.yaml
@@ -3,9 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: vector-{{ .Release.Name }}
+    app: {{ .Release.Name }}-vector
     gitsha: {{ .Values.gitSha }}
-  name: vector-{{ .Release.Name }}
+  name: {{ .Release.Name }}-vector
   {{- if .Values.vector.annotations }}
   annotations:
     {{- with .Values.vector.annotations }}
@@ -22,11 +22,11 @@ spec:
       maxUnavailable: 0
   selector:
     matchLabels:
-      app: vector-{{ .Release.Name }}
+      app: {{ .Release.Name }}-vector
   template:
     metadata:
       labels:
-        app: vector-{{ .Release.Name }}
+        app: {{ .Release.Name }}-vector
         {{- with .Values.vector.settings.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -85,7 +85,7 @@ spec:
           {{- include "eoapi.commonEnvVars" (dict "service" "vector" "root" .) | nindent 10 }}
         envFrom:
           - configMapRef:
-              name: vector-envvar-configmap-{{ .Release.Name }}
+              name: {{ .Release.Name }}-vector-envvar-configmap
           {{- if .Values.vector.settings.extraEnvFrom }}
           {{- toYaml .Values.vector.settings.extraEnvFrom | nindent 10 }}
           {{- end }}

--- a/charts/eoapi/templates/services/vector/hpa.yaml
+++ b/charts/eoapi/templates/services/vector/hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: vector-hpa-{{ .Release.Name }}
+  name: {{ .Release.Name }}-vector-hpa
   labels:
-    app: vector-{{ .Release.Name }}
+    app: {{ .Release.Name }}-vector
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: vector-{{ .Release.Name }}
+    name: {{ .Release.Name }}-vector
   minReplicas: {{ .Values.vector.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.vector.autoscaling.maxReplicas }}
   behavior:

--- a/charts/eoapi/templates/services/vector/service.yaml
+++ b/charts/eoapi/templates/services/vector/service.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: vector-{{ $.Release.Name }}
+  name: {{ .Release.Name }}-vector
   labels:
-    app: vector-{{ .Release.Name }}
+    app: {{ .Release.Name }}-vector
 spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.port }}
   selector:
-    app: vector-{{ .Release.Name }}
+    app: {{ .Release.Name }}-vector
 {{- end }}

--- a/charts/eoapi/tests/config_tests.yaml
+++ b/charts/eoapi/tests/config_tests.yaml
@@ -1,5 +1,0 @@
-# This file is kept for backward compatibility but tests have been moved to service-specific test files:
-# - raster_tests.yaml
-# - stac_tests.yaml
-# - vector_tests.yaml
-# - multidim_tests.yaml

--- a/charts/eoapi/tests/deploy_tests.yaml
+++ b/charts/eoapi/tests/deploy_tests.yaml
@@ -1,5 +1,0 @@
-# This file is kept for backward compatibility but tests have been moved to service-specific test files:
-# - raster_tests.yaml
-# - stac_tests.yaml
-# - vector_tests.yaml
-# - multidim_tests.yaml

--- a/charts/eoapi/tests/hpa_tests.yaml
+++ b/charts/eoapi/tests/hpa_tests.yaml
@@ -1,2 +1,0 @@
-# This file is kept for backward compatibility but tests have been moved to service-specific test files:
-# - vector_tests.yaml (for HPA tests)

--- a/charts/eoapi/tests/ingress_tests.yaml
+++ b/charts/eoapi/tests/ingress_tests.yaml
@@ -57,7 +57,7 @@ tests:
           path: metadata.annotations
           value:
             traefik.ingress.kubernetes.io/router.entrypoints: web
-            traefik.ingress.kubernetes.io/router.middlewares: NAMESPACE-strip-prefix-middleware-RELEASE-NAME@kubernetescrd
+            traefik.ingress.kubernetes.io/router.middlewares: NAMESPACE-RELEASE-NAME-strip-prefix-middleware@kubernetescrd
       - equal:
           path: spec.ingressClassName
           value: "traefik"
@@ -90,7 +90,7 @@ tests:
           value: "/"
       - equal:
           path: spec.rules[0].http.paths[1].backend.service.name
-          value: doc-server-RELEASE-NAME
+          value: RELEASE-NAME-doc-server
 
   - it: "custom paths for multiple services with nginx controller"
     set:
@@ -152,7 +152,7 @@ tests:
           path: metadata.annotations
           value:
             traefik.ingress.kubernetes.io/router.entrypoints: web
-            traefik.ingress.kubernetes.io/router.middlewares: NAMESPACE-strip-prefix-middleware-RELEASE-NAME@kubernetescrd
+            traefik.ingress.kubernetes.io/router.middlewares: NAMESPACE-RELEASE-NAME-strip-prefix-middleware@kubernetescrd
 
   - it: "multiple hosts with nginx controller"
     set:

--- a/charts/eoapi/tests/multidim_tests.yaml
+++ b/charts/eoapi/tests/multidim_tests.yaml
@@ -18,7 +18,7 @@ tests:
           of: Deployment
       - matchRegex:
           path: metadata.name
-          pattern: ^multidim-RELEASE-NAME$
+          pattern: ^RELEASE-NAME-multidim$
       - equal:
           path: spec.strategy.type
           value: "RollingUpdate"
@@ -50,7 +50,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: metadata.name
-          pattern: ^multidim-envvar-configmap-RELEASE-NAME$
+          pattern: ^RELEASE-NAME-multidim-envvar-configmap$
       - equal:
           path: data.GDAL_HTTP_MULTIPLEX
           value: "YES"

--- a/charts/eoapi/tests/raster_tests.yaml
+++ b/charts/eoapi/tests/raster_tests.yaml
@@ -18,7 +18,7 @@ tests:
           of: Deployment
       - matchRegex:
           path: metadata.name
-          pattern: ^raster-RELEASE-NAME$
+          pattern: ^RELEASE-NAME-raster$
       - equal:
           path: spec.strategy.type
           value: "RollingUpdate"
@@ -50,7 +50,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: metadata.name
-          pattern: ^raster-envvar-configmap-RELEASE-NAME$
+          pattern: ^RELEASE-NAME-raster-envvar-configmap$
       - equal:
           path: data.GDAL_HTTP_MULTIPLEX
           value: "YES"

--- a/charts/eoapi/tests/stac_browser_tests.yaml
+++ b/charts/eoapi/tests/stac_browser_tests.yaml
@@ -17,10 +17,10 @@ tests:
           of: Deployment
       - matchRegex:
           path: metadata.name
-          pattern: ^browser-RELEASE-NAME$
+          pattern: ^RELEASE-NAME-browser$
       - matchRegex:
           path: metadata.labels.app
-          pattern: ^browser-RELEASE-NAME$
+          pattern: ^RELEASE-NAME-browser$
       - equal:
           path: metadata.labels.gitsha
           value: "ABC123"
@@ -41,10 +41,10 @@ tests:
           of: Service
       - matchRegex:
           path: metadata.name
-          pattern: ^browser-RELEASE-NAME$
+          pattern: ^RELEASE-NAME-browser$
       - matchRegex:
           path: metadata.labels.app
-          pattern: ^browser-RELEASE-NAME$
+          pattern: ^RELEASE-NAME-browser$
       - equal:
           path: metadata.annotations.annotation1
           value: hello

--- a/charts/eoapi/tests/stac_tests.yaml
+++ b/charts/eoapi/tests/stac_tests.yaml
@@ -18,7 +18,7 @@ tests:
           of: Deployment
       - matchRegex:
           path: metadata.name
-          pattern: ^stac-RELEASE-NAME$
+          pattern: ^RELEASE-NAME-stac$
       - equal:
           path: spec.strategy.type
           value: "RollingUpdate"
@@ -50,7 +50,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: metadata.name
-          pattern: ^stac-envvar-configmap-RELEASE-NAME$
+          pattern: ^RELEASE-NAME-stac-envvar-configmap$
       - equal:
           path: data.WEB_CONCURRENCY
           value: "5"

--- a/charts/eoapi/tests/vector_tests.yaml
+++ b/charts/eoapi/tests/vector_tests.yaml
@@ -18,7 +18,7 @@ tests:
           of: Deployment
       - matchRegex:
           path: metadata.name
-          pattern: ^vector-RELEASE-NAME$
+          pattern: ^RELEASE-NAME-vector$
       - equal:
           path: spec.strategy.type
           value: "RollingUpdate"
@@ -50,7 +50,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: metadata.name
-          pattern: ^vector-envvar-configmap-RELEASE-NAME$
+          pattern: ^RELEASE-NAME-vector-envvar-configmap$
       - equal:
           path: data.TIPG_CATALOG_TTL
           value: "300"


### PR DESCRIPTION
This PR suggests naming all components after the following rule: `RELEASE_NAME-COMPONENT_NAME`

So instead of the current:

```
browser-XY-8464544b97-6brl5
doc-server-XY-545b8f9499-p6ddc
XY-XY-qx9h-0
XY-pgbouncer-554d89b8c7-mpdl5
XY-pgstac-load-samples-ktrbn
XY-pgstac-migrate-tzjwm
pgstac-XY-superuser-init-db-8bh7n
raster-XY-56996bc969-jkvws
stac-XY-665b44cd4-rtqw7
vector-XY-6f654bdd8-zlzlt
```

it will be:

```
XY-browser-7d98757fbb-nc8k6
XY-doc-server-5f9859cf85-8lr8f
XY-XY-4ckc-0
XY-pgbouncer-79485d68f7-2mc7m
XY-pgstac-load-samples-68hrb
XY-pgstac-migrate-jcmml
XY-pgstac-superuser-init-db-g8tqw
XY-raster-7466b67b6d-4f8nr
XY-stac-744c5487d9-wfwcd
XY-vector-67d46cb879-vxb5c
```

The prefix can be set freely with `helm install`. In most cases it would be `eoapi` instead of `XY`.