### PR TITLE
Add renovate for dependency management.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Renovate configuration for eoAPI Kubernetes charts",
+  "extends": [
+    "config:base",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":separatePatchReleases"
+  ],
+  "timezone": "UTC",
+  "schedule": ["after 10pm and before 5am every weekday"],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 5,
+  "commitMessagePrefix": "",
+  "commitMessageAction": "Updated",
+  "commitMessageTopic": "{{depName}}",
+  "commitMessageExtra": "to {{newVersion}}.",
+  "branchPrefix": "renovate/",
+  "includeForks": false,
+  "assigneesFromCodeOwners": true,
+  "reviewersFromCodeOwners": true,
+  "platformAutomerge": false,
+  "automerge": false,
+  "ignoreDeps": [],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "description": "Helm chart dependencies - individual PRs",
+      "matchManagers": ["helmv3"],
+      "matchFileNames": ["charts/**/Chart.yaml"],
+      "schedule": ["after 10pm and before 5am every weekday"],
+      "automerge": false,
+      "platformAutomerge": false,
+      "labels": ["dependencies", "helm"]
+    },
+    {
+      "description": "STAC ecosystem container images - individual PRs",
+      "matchManagers": ["helm-values"],
+      "matchPackagePatterns": [
+        "ghcr.io/stac-utils/pgstac-pypgstac",
+        "ghcr.io/stac-utils/titiler-pgstac",
+        "ghcr.io/stac-utils/stac-fastapi-pgstac"
+      ],
+      "schedule": ["after 10pm and before 5am every weekday"],
+      "automerge": false,
+      "platformAutomerge": false,
+      "labels": ["dependencies", "container-images", "stac"]
+    },
+    {
+      "description": "Development Seed container images - individual PRs",
+      "matchManagers": ["helm-values"],
+      "matchPackagePatterns": [
+        "ghcr.io/developmentseed/tipg",
+        "ghcr.io/developmentseed/titiler-md-demo",
+        "ghcr.io/developmentseed/eoapi-k8s-stac-browser"
+      ],
+      "schedule": ["after 10pm and before 5am every weekday"],
+      "automerge": false,
+      "platformAutomerge": false,
+      "labels": ["dependencies", "container-images", "developmentseed"]
+    },
+    {
+      "description": "Patch updates - no automerge, individual PRs",
+      "matchManagers": ["helm-values"],
+      "matchUpdateTypes": ["patch"],
+      "matchPackagePatterns": [
+        "ghcr.io/stac-utils/*",
+        "ghcr.io/developmentseed/*"
+      ],
+      "automerge": false,
+      "platformAutomerge": false,
+      "labels": ["dependencies", "patch"]
+    },
+    {
+      "description": "Minor updates - individual PRs",
+      "matchUpdateTypes": ["minor"],
+      "schedule": ["after 10pm and before 5am every weekday"],
+      "automerge": false,
+      "platformAutomerge": false,
+      "labels": ["dependencies", "minor-update"]
+    },
+    {
+      "description": "Major updates - individual PRs",
+      "matchUpdateTypes": ["major"],
+      "schedule": ["after 10pm and before 5am every weekday"],
+      "automerge": false,
+      "platformAutomerge": false,
+      "labels": ["dependencies", "major-update", "manual-review"],
+      "reviewers": ["@maintainers"]
+    }
+  ],
+  "helm-values": {
+    "fileMatch": [
+      "charts/**/values.yaml",
+      "charts/**/values.yml"
+    ]
+  },
+  "helmv3": {
+    "fileMatch": [
+      "charts/**/Chart.yaml",
+      "charts/**/Chart.yml"
+    ]
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update container image tags in Helm values files",
+      "fileMatch": [
+        "charts/.+/values\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "(?<depName>ghcr\\.io/[^\\s]+?)\\s*\\n\\s*tag:\\s*[\"']?(?<currentValue>[^\\s\"']+)[\"']?"
+      ],
+      "datasourceTemplate": "docker",
+      "registryUrlTemplate": "https://ghcr.io",
+      "versioningTemplate": "docker"
+    }
+  ],
+  "docker": {
+    "enabled": true,
+    "pinDigests": false
+  },
+  "regexManagers": [
+    {
+      "description": "Update image tags in values.yaml files",
+      "fileMatch": [
+        "charts/.+/values\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "name:\\s*[\"']?(?<depName>ghcr\\.io/.+?)[\"']?\\s*\\n.*?tag:\\s*[\"']?(?<currentValue>.+?)[\"']?"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    }
+  ],
+  "labels": ["dependencies"],
+  "assignees": [],
+  "reviewers": [],
+  "prBodyTemplate": "This PR updates {{depName}} in the eoAPI Kubernetes charts.\n\n**Update details:**\n- **From:** {{currentVersion}}\n- **To:** {{newVersion}}\n- **Type:** {{updateType}} update\n\n**Release notes:**\n{{{changelog}}}\n\n**Testing checklist:**\n- [ ] Verify Helm chart templates render correctly\n- [ ] Test deployment in development environment\n- [ ] Check for any breaking changes in release notes\n- [ ] Validate container image exists and is functional\n\n---\n**Auto-generated by Renovate Bot** 🤖",
+  "prFooter": "---\n\n**Need help?** Check the [Renovate documentation](https://docs.renovatebot.com/) or [eoAPI documentation](https://eoapi.dev/).",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["after 10pm and before 5am on sunday"]
+  }
+}


### PR DESCRIPTION
I suggest introducing _[Renovate](https://docs.renovatebot.com/)_ to regularly check on updates of helm chart dependencies and component images and create PRs automatically for it.