### PR TITLE
fix: move to bitnamilegacy registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Excluded renovate.json from CHANGELOG.md edits [#301](https://github.com/developmentseed/eoapi-k8s/pull/301)
 
+### Fixed
+
+- Pin `metrics-server` to `bitnamilegacy` registry due to https://github.com/bitnami/charts/issues/35164 [#309](https://github.com/developmentseed/eoapi-k8s/pull/309)
+
 ## [0.7.8] - 2025-09-10
 
 ### Added

--- a/charts/eoapi-support/values.yaml
+++ b/charts/eoapi-support/values.yaml
@@ -170,5 +170,9 @@ grafana:
     default: "eoapi-support-dashboards"
 
 metrics-server:
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/metrics-server
+    tag: "0.8.0-debian-12-r4"
   apiService:
     create: true


### PR DESCRIPTION
# What this PR is:

Due to: https://github.com/bitnami/charts/issues/35164 - Any new deploys/pulls of images that point to `bitnami`'s registry (`metrics-server` in `eoapi-support` in our case) will now fail. The tag our current pinned version points to has been moved to the `bitnamilegacy` registry so this ensures we can still make deployments for now.

# How I did it

- Overrode `metrics-server`'s values.yaml entries for `eoapi-support`
